### PR TITLE
geom_alt props

### DIFF
--- a/data/101/752/049/101752049.geojson
+++ b/data/101/752/049/101752049.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Nitra"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"657aaf91b2106d735389e6004f932b04",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645688,
+    "wof:lastmodified":1582382505,
     "wof:name":"Nitra",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/752/051/101752051.geojson
+++ b/data/101/752/051/101752051.geojson
@@ -372,6 +372,9 @@
         "wk:page":"Trnava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b0e6735a4bf3061368e328b1781e13c",
     "wof:hierarchy":[
         {
@@ -386,7 +389,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645690,
+    "wof:lastmodified":1582382506,
     "wof:name":"Trnava",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/752/053/101752053.geojson
+++ b/data/101/752/053/101752053.geojson
@@ -396,6 +396,9 @@
         "wk:page":"Bansk\u00e1 Bystrica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1266f373c27609afeb5672958e3dcf8a",
     "wof:hierarchy":[
         {
@@ -410,7 +413,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645688,
+    "wof:lastmodified":1582382505,
     "wof:name":"Bansk\u00e1 Bystrica",
     "wof:parent_id":102080531,
     "wof:placetype":"locality",

--- a/data/101/752/055/101752055.geojson
+++ b/data/101/752/055/101752055.geojson
@@ -444,6 +444,9 @@
         "wk:page":"Ko\u0161ice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cb9198ae68e4e1c4a19ef411431a8740",
     "wof:hierarchy":[
         {
@@ -458,7 +461,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645689,
+    "wof:lastmodified":1582382506,
     "wof:name":"Ko\u0161ice",
     "wof:parent_id":102080549,
     "wof:placetype":"locality",

--- a/data/101/752/057/101752057.geojson
+++ b/data/101/752/057/101752057.geojson
@@ -211,6 +211,9 @@
         "wk:page":"Prievidza"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5c9c8b15e359b316040b2861ee1d027",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":101752057,
-    "wof:lastmodified":1566645689,
+    "wof:lastmodified":1582382506,
     "wof:name":"Prievidza",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/752/059/101752059.geojson
+++ b/data/101/752/059/101752059.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Tren\u010d\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ee946d8b0a007f98e42e01ff91f9760d",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645689,
+    "wof:lastmodified":1582382506,
     "wof:name":"Tren\u010d\u00edn",
     "wof:parent_id":102080541,
     "wof:placetype":"locality",

--- a/data/101/752/061/101752061.geojson
+++ b/data/101/752/061/101752061.geojson
@@ -250,6 +250,9 @@
         "wk:page":"Martin, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c857cb912a4e30c730f017e1aee80f5a",
     "wof:hierarchy":[
         {
@@ -264,7 +267,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645689,
+    "wof:lastmodified":1582382506,
     "wof:name":"Martin",
     "wof:parent_id":102080569,
     "wof:placetype":"locality",

--- a/data/101/752/063/101752063.geojson
+++ b/data/101/752/063/101752063.geojson
@@ -397,6 +397,9 @@
         "wk:page":"\u017dilina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3a819eb45514e4bb490a567768e15ce",
     "wof:hierarchy":[
         {
@@ -411,7 +414,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645689,
+    "wof:lastmodified":1582382506,
     "wof:name":"\u017dilina",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/752/067/101752067.geojson
+++ b/data/101/752/067/101752067.geojson
@@ -396,6 +396,9 @@
         "wk:page":"Pre\u0161ov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a449fb19b4efb2918374243cfd512c5b",
     "wof:hierarchy":[
         {
@@ -410,7 +413,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645690,
+    "wof:lastmodified":1582382506,
     "wof:name":"Pre\u0161ov",
     "wof:parent_id":102080591,
     "wof:placetype":"locality",

--- a/data/101/752/069/101752069.geojson
+++ b/data/101/752/069/101752069.geojson
@@ -238,6 +238,9 @@
         "wk:page":"Poprad"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ddd6fadf735204b27057354a735b9f13",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645690,
+    "wof:lastmodified":1582382506,
     "wof:name":"Poprad",
     "wof:parent_id":102080597,
     "wof:placetype":"locality",

--- a/data/101/754/897/101754897.geojson
+++ b/data/101/754/897/101754897.geojson
@@ -116,6 +116,9 @@
         "qs_pg:id":1182482
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9a7d7bfbf4f33e626454b05f0ef86ce1",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101754897,
-    "wof:lastmodified":1566645691,
+    "wof:lastmodified":1582382506,
     "wof:name":"Zbehy",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/754/899/101754899.geojson
+++ b/data/101/754/899/101754899.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Lu\u017eianky"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c2f86f77c834e2c34cbcece7acfeb4b",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645691,
+    "wof:lastmodified":1582382506,
     "wof:name":"Lu\u017eianky",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/754/903/101754903.geojson
+++ b/data/101/754/903/101754903.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Opatovce nad Nitrou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46c1f63e2268f271044336c5b4aaef31",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101754903,
-    "wof:lastmodified":1566645691,
+    "wof:lastmodified":1582382506,
     "wof:name":"Opatovce nad Nitrou",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/754/905/101754905.geojson
+++ b/data/101/754/905/101754905.geojson
@@ -189,6 +189,9 @@
         "wk:page":"Bojnice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80db297f023d38dcb6543069ee3f1e83",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
         }
     ],
     "wof:id":101754905,
-    "wof:lastmodified":1566645691,
+    "wof:lastmodified":1582382506,
     "wof:name":"Bojnice",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/754/907/101754907.geojson
+++ b/data/101/754/907/101754907.geojson
@@ -168,6 +168,9 @@
         "wk:page":"Vr\u00fatky"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bc5b9f4b047304d6ecab32520f6ff5c8",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":101754907,
-    "wof:lastmodified":1566645690,
+    "wof:lastmodified":1582382506,
     "wof:name":"Vr\u00fatky",
     "wof:parent_id":102080569,
     "wof:placetype":"locality",

--- a/data/101/780/201/101780201.geojson
+++ b/data/101/780/201/101780201.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Nesvady"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c19aea131b55e82ba885535b7effb302",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101780201,
-    "wof:lastmodified":1566645821,
+    "wof:lastmodified":1582382518,
     "wof:name":"Nesvady",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/101/780/203/101780203.geojson
+++ b/data/101/780/203/101780203.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Ohrady"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bfaeee8be0805dbf4da36237cf6bed99",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101780203,
-    "wof:lastmodified":1566645807,
+    "wof:lastmodified":1582382517,
     "wof:name":"Ohrady",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/780/205/101780205.geojson
+++ b/data/101/780/205/101780205.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Trhov\u00e1 Hradsk\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e23b429f610ce7dd14affac537ecb0f",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780205,
-    "wof:lastmodified":1566645809,
+    "wof:lastmodified":1582382517,
     "wof:name":"Trhov\u00e1 Hradsk\u00e1",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/780/207/101780207.geojson
+++ b/data/101/780/207/101780207.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Strekov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ab66f1e685ccd96f6fe2a764fe1b4503",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780207,
-    "wof:lastmodified":1566645820,
+    "wof:lastmodified":1582382518,
     "wof:name":"Strekov",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/780/211/101780211.geojson
+++ b/data/101/780/211/101780211.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Kamenn\u00fd Most (Nov\u00e9 Z\u00e1mky District)"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db9b306e4f5536d0407a8cb86f940b4b",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101780211,
-    "wof:lastmodified":1566645801,
+    "wof:lastmodified":1582382517,
     "wof:name":"Kamenn\u00fd Most",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/780/213/101780213.geojson
+++ b/data/101/780/213/101780213.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Chtelnica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f5880a12133c47e2c46df6b3e4f96c6",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780213,
-    "wof:lastmodified":1566645820,
+    "wof:lastmodified":1582382518,
     "wof:name":"Chtelnica",
     "wof:parent_id":102080495,
     "wof:placetype":"locality",

--- a/data/101/780/215/101780215.geojson
+++ b/data/101/780/215/101780215.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Rado\u0161ina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89448313772f42ce037577f717f35055",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780215,
-    "wof:lastmodified":1566645817,
+    "wof:lastmodified":1582382518,
     "wof:name":"Rado\u0161ina",
     "wof:parent_id":102080501,
     "wof:placetype":"locality",

--- a/data/101/780/219/101780219.geojson
+++ b/data/101/780/219/101780219.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Urmince"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f2cad4f75290b40f909a434c247ff3d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780219,
-    "wof:lastmodified":1566645804,
+    "wof:lastmodified":1582382517,
     "wof:name":"Urmince",
     "wof:parent_id":102080501,
     "wof:placetype":"locality",

--- a/data/101/780/221/101780221.geojson
+++ b/data/101/780/221/101780221.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Mur\u00e1\u0148"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2d5eb689c4df40bb0dc1eac10fafb004",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101780221,
-    "wof:lastmodified":1566645803,
+    "wof:lastmodified":1582382517,
     "wof:name":"Mur\u00e1\u0148",
     "wof:parent_id":102080527,
     "wof:placetype":"locality",

--- a/data/101/780/223/101780223.geojson
+++ b/data/101/780/223/101780223.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Nitrianske Pravno"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9137d99b92782dedc04500bf5eee09ff",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101780223,
-    "wof:lastmodified":1566645818,
+    "wof:lastmodified":1582382518,
     "wof:name":"Nitrianske Pravno",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/780/227/101780227.geojson
+++ b/data/101/780/227/101780227.geojson
@@ -193,6 +193,9 @@
         "wk:page":"Brezno"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfdce0d0f0db58eff4a079cd029acd58",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645801,
+    "wof:lastmodified":1582382517,
     "wof:name":"Brezno",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/780/231/101780231.geojson
+++ b/data/101/780/231/101780231.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Telg\u00e1rt"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ce20a67d6f7f17666b80e4adfb87814",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780231,
-    "wof:lastmodified":1566645820,
+    "wof:lastmodified":1582382518,
     "wof:name":"Telg\u00e1rt",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/780/239/101780239.geojson
+++ b/data/101/780/239/101780239.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Ko\u0161eca"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9c1e5c4b177e711ef0a34a9bea0cc8b",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780239,
-    "wof:lastmodified":1566645821,
+    "wof:lastmodified":1582382518,
     "wof:name":"Ko\u0161eca",
     "wof:parent_id":102080555,
     "wof:placetype":"locality",

--- a/data/101/780/243/101780243.geojson
+++ b/data/101/780/243/101780243.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Dru\u017estevn\u00e1 pri Horn\u00e1de"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f40e1ee6d1ee15f20ac9ca5452faa22d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780243,
-    "wof:lastmodified":1566645804,
+    "wof:lastmodified":1582382517,
     "wof:name":"Dru\u017estevn\u00e1 pri Horn\u00e1de",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/780/245/101780245.geojson
+++ b/data/101/780/245/101780245.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Rozhanovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb15d85d589394bf81012f1b02d13649",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101780245,
-    "wof:lastmodified":1566645803,
+    "wof:lastmodified":1582382517,
     "wof:name":"Rozhanovce",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/780/255/101780255.geojson
+++ b/data/101/780/255/101780255.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Margecany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1220679f7c3a6aea7344fda5fbde7c06",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780255,
-    "wof:lastmodified":1566645822,
+    "wof:lastmodified":1582382518,
     "wof:name":"Margecany",
     "wof:parent_id":102080559,
     "wof:placetype":"locality",

--- a/data/101/780/263/101780263.geojson
+++ b/data/101/780/263/101780263.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Hrabu\u0161ice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca3fa1b8ad42db31e5a388f1f802ea65",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780263,
-    "wof:lastmodified":1566645822,
+    "wof:lastmodified":1582382518,
     "wof:name":"Hrabu\u0161ice",
     "wof:parent_id":102080561,
     "wof:placetype":"locality",

--- a/data/101/780/267/101780267.geojson
+++ b/data/101/780/267/101780267.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Spi\u0161sk\u00e9 Tom\u00e1\u0161ovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"28bbd7aaf27b4c3a58c1dc94b3cbc5ee",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780267,
-    "wof:lastmodified":1566645807,
+    "wof:lastmodified":1582382517,
     "wof:name":"Spi\u0161sk\u00e9 Tom\u00e1\u0161ovce",
     "wof:parent_id":102080561,
     "wof:placetype":"locality",

--- a/data/101/780/275/101780275.geojson
+++ b/data/101/780/275/101780275.geojson
@@ -177,6 +177,9 @@
         "qs_pg:id":1014297
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11f6352fec9635aa92363305196e4bac",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":101780275,
-    "wof:lastmodified":1566645804,
+    "wof:lastmodified":1582382517,
     "wof:name":"Spi\u0161sk\u00e9 Vlachy",
     "wof:parent_id":102080561,
     "wof:placetype":"locality",

--- a/data/101/780/283/101780283.geojson
+++ b/data/101/780/283/101780283.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Krompachy"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7d56002bb9300ce0ba16bd46c3871861",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101780283,
-    "wof:lastmodified":1566645817,
+    "wof:lastmodified":1582382518,
     "wof:name":"Krompachy",
     "wof:parent_id":102080561,
     "wof:placetype":"locality",

--- a/data/101/780/285/101780285.geojson
+++ b/data/101/780/285/101780285.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Str\u00e1\u017eske"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"041c29fec8782ef963c27696dfb0d14b",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101780285,
-    "wof:lastmodified":1566645819,
+    "wof:lastmodified":1582382518,
     "wof:name":"Str\u00e1\u017eske",
     "wof:parent_id":102080563,
     "wof:placetype":"locality",

--- a/data/101/780/291/101780291.geojson
+++ b/data/101/780/291/101780291.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Rakovec nad Ondavou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc7e3e4296043b383621d8f1da21bb07",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780291,
-    "wof:lastmodified":1566645820,
+    "wof:lastmodified":1582382518,
     "wof:name":"Rakovec nad Ondavou",
     "wof:parent_id":102080563,
     "wof:placetype":"locality",

--- a/data/101/780/295/101780295.geojson
+++ b/data/101/780/295/101780295.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Pozdi\u0161ovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"59a3b39e5abe965bce48895cc1f5756f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780295,
-    "wof:lastmodified":1566645806,
+    "wof:lastmodified":1582382517,
     "wof:name":"Pozdi\u0161ovce",
     "wof:parent_id":102080563,
     "wof:placetype":"locality",

--- a/data/101/780/301/101780301.geojson
+++ b/data/101/780/301/101780301.geojson
@@ -200,6 +200,9 @@
         "wk:page":"Michalovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"765c9f07bacd3a9abc30d0ccb68f961d",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645800,
+    "wof:lastmodified":1582382516,
     "wof:name":"Michalovce",
     "wof:parent_id":102080563,
     "wof:placetype":"locality",

--- a/data/101/780/309/101780309.geojson
+++ b/data/101/780/309/101780309.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Hubov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4126795048dcd110855161dfc84cfdb7",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780309,
-    "wof:lastmodified":1566645799,
+    "wof:lastmodified":1582382516,
     "wof:name":"Hubov\u00e1",
     "wof:parent_id":102080567,
     "wof:placetype":"locality",

--- a/data/101/780/317/101780317.geojson
+++ b/data/101/780/317/101780317.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Kl\u00e1\u0161tor pod Znievom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98cdba93999d9497ff8b830187639d16",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780317,
-    "wof:lastmodified":1566645825,
+    "wof:lastmodified":1582382519,
     "wof:name":"Kl\u00e1\u0161tor pod Znievom",
     "wof:parent_id":102080569,
     "wof:placetype":"locality",

--- a/data/101/780/323/101780323.geojson
+++ b/data/101/780/323/101780323.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Su\u010dany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c54d391daab2d226a0b2974e3fc538fe",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101780323,
-    "wof:lastmodified":1566645810,
+    "wof:lastmodified":1582382517,
     "wof:name":"Su\u010dany",
     "wof:parent_id":102080569,
     "wof:placetype":"locality",

--- a/data/101/780/329/101780329.geojson
+++ b/data/101/780/329/101780329.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Sobrance"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"faddbd640cc90be2b0172d18fd00695b",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645824,
+    "wof:lastmodified":1582382519,
     "wof:name":"Sobrance",
     "wof:parent_id":102080571,
     "wof:placetype":"locality",

--- a/data/101/780/331/101780331.geojson
+++ b/data/101/780/331/101780331.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Lazy pod Makytou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4075d316bd4b7c135fdfa7c3b1617a67",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780331,
-    "wof:lastmodified":1566645799,
+    "wof:lastmodified":1582382516,
     "wof:name":"Lazy pod Makytou",
     "wof:parent_id":102080573,
     "wof:placetype":"locality",

--- a/data/101/780/333/101780333.geojson
+++ b/data/101/780/333/101780333.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Lys\u00e1 pod Makytou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48a5890845fc996c31567cf671a861a0",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780333,
-    "wof:lastmodified":1566645816,
+    "wof:lastmodified":1582382518,
     "wof:name":"Lys\u00e1 pod Makytou",
     "wof:parent_id":102080573,
     "wof:placetype":"locality",

--- a/data/101/780/335/101780335.geojson
+++ b/data/101/780/335/101780335.geojson
@@ -180,6 +180,9 @@
         "wk:page":"P\u00fachov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"54c9c36ddff6a14bd7c22a2666b9dc06",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":101780335,
-    "wof:lastmodified":1566645814,
+    "wof:lastmodified":1582382518,
     "wof:name":"P\u00fachov",
     "wof:parent_id":102080573,
     "wof:placetype":"locality",

--- a/data/101/780/345/101780345.geojson
+++ b/data/101/780/345/101780345.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Domani\u017ea"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fabeec0e918d8bd71ba2152d5b684389",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780345,
-    "wof:lastmodified":1566645825,
+    "wof:lastmodified":1582382519,
     "wof:name":"Domani\u017ea",
     "wof:parent_id":102080575,
     "wof:placetype":"locality",

--- a/data/101/780/349/101780349.geojson
+++ b/data/101/780/349/101780349.geojson
@@ -197,6 +197,9 @@
         "qs_pg:id":892360
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3131c53fa6f612a0c98dab29e2d45f4f",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645811,
+    "wof:lastmodified":1582382517,
     "wof:name":"Pova\u017esk\u00e1 Bystrica",
     "wof:parent_id":102080575,
     "wof:placetype":"locality",

--- a/data/101/780/353/101780353.geojson
+++ b/data/101/780/353/101780353.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Pribylina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac77f49bb1f75743452fe502ece0b007",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645800,
+    "wof:lastmodified":1582382516,
     "wof:name":"Pribylina",
     "wof:parent_id":102080577,
     "wof:placetype":"locality",

--- a/data/101/780/363/101780363.geojson
+++ b/data/101/780/363/101780363.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Va\u017eec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86d63b01b902b2def6a6132b98e7c761",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780363,
-    "wof:lastmodified":1566645800,
+    "wof:lastmodified":1582382517,
     "wof:name":"Va\u017eec",
     "wof:parent_id":102080577,
     "wof:placetype":"locality",

--- a/data/101/780/365/101780365.geojson
+++ b/data/101/780/365/101780365.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Hybe"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4be3ccf9a42378f78440a0f5a0dbc27e",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780365,
-    "wof:lastmodified":1566645799,
+    "wof:lastmodified":1582382516,
     "wof:name":"Hybe",
     "wof:parent_id":102080577,
     "wof:placetype":"locality",

--- a/data/101/780/367/101780367.geojson
+++ b/data/101/780/367/101780367.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Liptovsk\u00fd Hr\u00e1dok"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04cfcb3c8787902803ac9d9d6ee5a0eb",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101780367,
-    "wof:lastmodified":1566645815,
+    "wof:lastmodified":1582382518,
     "wof:name":"Liptovsk\u00fd Hr\u00e1dok",
     "wof:parent_id":102080577,
     "wof:placetype":"locality",

--- a/data/101/780/369/101780369.geojson
+++ b/data/101/780/369/101780369.geojson
@@ -225,6 +225,9 @@
         "wd:id":"Q272040"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d3d01eec0dea2f9130890c96b51160cf",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645815,
+    "wof:lastmodified":1582382518,
     "wof:name":"Liptovsk\u00fd Mikul\u00e1\u0161",
     "wof:parent_id":102080577,
     "wof:placetype":"locality",

--- a/data/101/780/371/101780371.geojson
+++ b/data/101/780/371/101780371.geojson
@@ -210,6 +210,9 @@
         "wk:page":"Levo\u010da"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2a8c4ac9a0b394d3a4c1dfa1fcde61e3",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645811,
+    "wof:lastmodified":1582382517,
     "wof:name":"Levo\u010da",
     "wof:parent_id":102080579,
     "wof:placetype":"locality",

--- a/data/101/780/373/101780373.geojson
+++ b/data/101/780/373/101780373.geojson
@@ -176,6 +176,9 @@
         "wk:page":"Spi\u0161sk\u00e9 Podhradie"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80ad037463f90538ca560c94d571db25",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":101780373,
-    "wof:lastmodified":1566645825,
+    "wof:lastmodified":1582382519,
     "wof:name":"Spi\u0161sk\u00e9 Podhradie",
     "wof:parent_id":102080579,
     "wof:placetype":"locality",

--- a/data/101/780/377/101780377.geojson
+++ b/data/101/780/377/101780377.geojson
@@ -191,6 +191,9 @@
         "wk:page":"Byt\u010da"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f0fa0244c502bd4916fba0f169f1f31",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645810,
+    "wof:lastmodified":1582382517,
     "wof:name":"Byt\u010da",
     "wof:parent_id":102080581,
     "wof:placetype":"locality",

--- a/data/101/780/383/101780383.geojson
+++ b/data/101/780/383/101780383.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Doln\u00fd Hri\u010dov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ede2590cc9ac6c6e8bfc263e92188a42",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645809,
+    "wof:lastmodified":1582382517,
     "wof:name":"Doln\u00fd Hri\u010dov",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/780/391/101780391.geojson
+++ b/data/101/780/391/101780391.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Doln\u00e1 Ti\u017eina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a441de8b8c2621fc8d0f01852093c89f",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645799,
+    "wof:lastmodified":1582382516,
     "wof:name":"Doln\u00e1 Ti\u017eina",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/780/403/101780403.geojson
+++ b/data/101/780/403/101780403.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Oravsk\u00fd Podz\u00e1mok"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7300aae8c9a73f489b6bf09a0a72d15b",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101780403,
-    "wof:lastmodified":1566645823,
+    "wof:lastmodified":1582382518,
     "wof:name":"Oravsk\u00fd Podz\u00e1mok",
     "wof:parent_id":102080587,
     "wof:placetype":"locality",

--- a/data/101/780/407/101780407.geojson
+++ b/data/101/780/407/101780407.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Istebn\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a8f5bac6448ccd8e436a01b6f2e8af8",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780407,
-    "wof:lastmodified":1566645808,
+    "wof:lastmodified":1582382517,
     "wof:name":"Istebn\u00e9",
     "wof:parent_id":102080587,
     "wof:placetype":"locality",

--- a/data/101/780/409/101780409.geojson
+++ b/data/101/780/409/101780409.geojson
@@ -199,6 +199,9 @@
         "wk:page":"Doln\u00fd Kub\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2f9e332697e649ded65e5cd6bc93d4e",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645807,
+    "wof:lastmodified":1582382517,
     "wof:name":"Doln\u00fd Kub\u00edn",
     "wof:parent_id":102080587,
     "wof:placetype":"locality",

--- a/data/101/780/427/101780427.geojson
+++ b/data/101/780/427/101780427.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Fintice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d03c19c0ca2bf77e8e60f987d2fb633f",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645819,
+    "wof:lastmodified":1582382518,
     "wof:name":"Fintice",
     "wof:parent_id":102080591,
     "wof:placetype":"locality",

--- a/data/101/780/429/101780429.geojson
+++ b/data/101/780/429/101780429.geojson
@@ -121,6 +121,9 @@
         "wk:page":"Kapu\u0161any"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"393a261ca17381021c13719dfbf20e45",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645818,
+    "wof:lastmodified":1582382518,
     "wof:name":"Kapu\u0161any",
     "wof:parent_id":102080591,
     "wof:placetype":"locality",

--- a/data/101/780/443/101780443.geojson
+++ b/data/101/780/443/101780443.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Bystr\u00e9, Vranov nad Top\u013eou District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd38bbca5f52938a2548e355ca62e2bb",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780443,
-    "wof:lastmodified":1566645817,
+    "wof:lastmodified":1582382518,
     "wof:name":"Bystr\u00e9",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/780/445/101780445.geojson
+++ b/data/101/780/445/101780445.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Hlinn\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fd3284d2a866ce07619ba9b10bede881",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780445,
-    "wof:lastmodified":1566645819,
+    "wof:lastmodified":1582382518,
     "wof:name":"Hlinn\u00e9",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/780/455/101780455.geojson
+++ b/data/101/780/455/101780455.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Z\u00e1mutov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4fc601df890347f88fbbdc6071146b4a",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780455,
-    "wof:lastmodified":1566645807,
+    "wof:lastmodified":1582382517,
     "wof:name":"Z\u00e1mutov",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/780/457/101780457.geojson
+++ b/data/101/780/457/101780457.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Sedlisk\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c97fb250723affd7742d8a8474b184a9",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101780457,
-    "wof:lastmodified":1566645821,
+    "wof:lastmodified":1582382518,
     "wof:name":"Sedlisk\u00e1",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/780/459/101780459.geojson
+++ b/data/101/780/459/101780459.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Vechec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ec48d36f5278971903656d5c2a5bb4f",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101780459,
-    "wof:lastmodified":1566645822,
+    "wof:lastmodified":1582382518,
     "wof:name":"Vechec",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/780/461/101780461.geojson
+++ b/data/101/780/461/101780461.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Bansk\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f026b0374269a499e920e77f5f138479",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780461,
-    "wof:lastmodified":1566645821,
+    "wof:lastmodified":1582382518,
     "wof:name":"Bansk\u00e9",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/780/467/101780467.geojson
+++ b/data/101/780/467/101780467.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Ni\u017en\u00fd Hru\u0161ov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d89187ffd0f4a631d374d40635f6f2a8",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780467,
-    "wof:lastmodified":1566645820,
+    "wof:lastmodified":1582382518,
     "wof:name":"Ni\u017en\u00fd Hru\u0161ov",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/780/471/101780471.geojson
+++ b/data/101/780/471/101780471.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Se\u010dovsk\u00e1 Polianka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"782cbe867333ebb1d65af32829947212",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780471,
-    "wof:lastmodified":1566645801,
+    "wof:lastmodified":1582382517,
     "wof:name":"Se\u010dovsk\u00e1 Polianka",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/780/481/101780481.geojson
+++ b/data/101/780/481/101780481.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Lipany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c0d743337f51a79681928cb5e5cbf8fc",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":101780481,
-    "wof:lastmodified":1566645818,
+    "wof:lastmodified":1582382518,
     "wof:name":"Lipany",
     "wof:parent_id":102080595,
     "wof:placetype":"locality",

--- a/data/101/780/501/101780501.geojson
+++ b/data/101/780/501/101780501.geojson
@@ -131,6 +131,9 @@
         "wk:page":"\u017ddiar"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"12136e9a025620afadcd2b3253b181e8",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645813,
+    "wof:lastmodified":1582382518,
     "wof:name":"\u017ddiar",
     "wof:parent_id":102080597,
     "wof:placetype":"locality",

--- a/data/101/780/503/101780503.geojson
+++ b/data/101/780/503/101780503.geojson
@@ -126,6 +126,9 @@
         "wk:page":"Nov\u00e1 Lesn\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9b070babf0ad45beb2f2884dfa23ea54",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645800,
+    "wof:lastmodified":1582382517,
     "wof:name":"Nov\u00e1 Lesn\u00e1",
     "wof:parent_id":102080597,
     "wof:placetype":"locality",

--- a/data/101/780/519/101780519.geojson
+++ b/data/101/780/519/101780519.geojson
@@ -116,6 +116,9 @@
         "wd:id":"Q1025195"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"809fdf5076825535f6677effb3ce6cbd",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780519,
-    "wof:lastmodified":1566645810,
+    "wof:lastmodified":1582382517,
     "wof:name":"Spi\u0161sk\u00e9 Bystr\u00e9",
     "wof:parent_id":102080597,
     "wof:placetype":"locality",

--- a/data/101/780/521/101780521.geojson
+++ b/data/101/780/521/101780521.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Hranovnica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"69cb498dc8d801644b9fd1ea793660ad",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780521,
-    "wof:lastmodified":1566645810,
+    "wof:lastmodified":1582382517,
     "wof:name":"Hranovnica",
     "wof:parent_id":102080597,
     "wof:placetype":"locality",

--- a/data/101/780/525/101780525.geojson
+++ b/data/101/780/525/101780525.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Liptovsk\u00e1 Tepli\u010dka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef075e4d60deaba95f39f9f10339ed81",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101780525,
-    "wof:lastmodified":1566645825,
+    "wof:lastmodified":1582382519,
     "wof:name":"Liptovsk\u00e1 Tepli\u010dka",
     "wof:parent_id":102080597,
     "wof:placetype":"locality",

--- a/data/101/780/551/101780551.geojson
+++ b/data/101/780/551/101780551.geojson
@@ -115,6 +115,9 @@
         "wd:id":"Q942639"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ce5f04f21951e44490bac99b21d22e6",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101780551,
-    "wof:lastmodified":1566645798,
+    "wof:lastmodified":1582382516,
     "wof:name":"Ni\u017en\u00e1",
     "wof:parent_id":102080605,
     "wof:placetype":"locality",

--- a/data/101/780/553/101780553.geojson
+++ b/data/101/780/553/101780553.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Podbiel"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7463ae0bc737f7b6cba34c987b4131a",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101780553,
-    "wof:lastmodified":1566645816,
+    "wof:lastmodified":1582382518,
     "wof:name":"Podbiel",
     "wof:parent_id":102080605,
     "wof:placetype":"locality",

--- a/data/101/780/561/101780561.geojson
+++ b/data/101/780/561/101780561.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Vitanov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"803ddf364bc0cf86a09620ceeb273c75",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101780561,
-    "wof:lastmodified":1566645800,
+    "wof:lastmodified":1582382516,
     "wof:name":"Vitanov\u00e1",
     "wof:parent_id":102080605,
     "wof:placetype":"locality",

--- a/data/101/780/571/101780571.geojson
+++ b/data/101/780/571/101780571.geojson
@@ -155,6 +155,9 @@
         "wd:id":"Q605059"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3fe4b03bed43371b89e018f6ddd6a7d6",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":101780571,
-    "wof:lastmodified":1566645824,
+    "wof:lastmodified":1582382519,
     "wof:name":"Spi\u0161sk\u00e1 Bel\u00e1",
     "wof:parent_id":102080609,
     "wof:placetype":"locality",

--- a/data/101/780/575/101780575.geojson
+++ b/data/101/780/575/101780575.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Huncovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a87e96fc3a688eb15e84d0977511b1a",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101780575,
-    "wof:lastmodified":1566645810,
+    "wof:lastmodified":1582382517,
     "wof:name":"Huncovce",
     "wof:parent_id":102080609,
     "wof:placetype":"locality",

--- a/data/101/780/579/101780579.geojson
+++ b/data/101/780/579/101780579.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Vrbov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46f7a97e7231a85a70cc33b696049671",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":101780579,
-    "wof:lastmodified":1566645826,
+    "wof:lastmodified":1582382519,
     "wof:name":"Vrbov",
     "wof:parent_id":102080609,
     "wof:placetype":"locality",

--- a/data/101/780/587/101780587.geojson
+++ b/data/101/780/587/101780587.geojson
@@ -228,6 +228,9 @@
         "wk:page":"Podol\u00ednec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3be40c1f863075f471a51d2ddaf999c",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":101780587,
-    "wof:lastmodified":1566645813,
+    "wof:lastmodified":1582382517,
     "wof:name":"Podol\u00ednec",
     "wof:parent_id":102080611,
     "wof:placetype":"locality",

--- a/data/101/780/597/101780597.geojson
+++ b/data/101/780/597/101780597.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Hru\u0161t\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"630ea2617555216daae0c74f8cc95f57",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101780597,
-    "wof:lastmodified":1566645814,
+    "wof:lastmodified":1582382518,
     "wof:name":"Hru\u0161t\u00edn",
     "wof:parent_id":102080615,
     "wof:placetype":"locality",

--- a/data/101/780/599/101780599.geojson
+++ b/data/101/780/599/101780599.geojson
@@ -165,6 +165,9 @@
         "wk:page":"Medzilaborce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76ada8d90e15f5d59addda0c06994445",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":101780599,
-    "wof:lastmodified":1566645814,
+    "wof:lastmodified":1582382518,
     "wof:name":"Medzilaborce",
     "wof:parent_id":102080617,
     "wof:placetype":"locality",

--- a/data/101/780/611/101780611.geojson
+++ b/data/101/780/611/101780611.geojson
@@ -237,6 +237,9 @@
         "wd:id":"Q27007"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3abf6d094423b38f5e46c9b30dde7c8",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645804,
+    "wof:lastmodified":1582382517,
     "wof:name":"Bardejov",
     "wof:parent_id":102080621,
     "wof:placetype":"locality",

--- a/data/101/780/615/101780615.geojson
+++ b/data/101/780/615/101780615.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Kurima"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd5e82fb6e1de1c8f4a1a787188a901f",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101780615,
-    "wof:lastmodified":1566645819,
+    "wof:lastmodified":1582382518,
     "wof:name":"Kurima",
     "wof:parent_id":102080621,
     "wof:placetype":"locality",

--- a/data/101/780/617/101780617.geojson
+++ b/data/101/780/617/101780617.geojson
@@ -159,6 +159,9 @@
         "wk:page":"Giraltovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10045a2b85306309f75e6f25bdf850c8",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":101780617,
-    "wof:lastmodified":1566645802,
+    "wof:lastmodified":1582382517,
     "wof:name":"Giraltovce",
     "wof:parent_id":102080623,
     "wof:placetype":"locality",

--- a/data/101/780/621/101780621.geojson
+++ b/data/101/780/621/101780621.geojson
@@ -169,6 +169,9 @@
         "wd:id":"Q833845"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"18dc22fb28126b0aee789ad90a5764a8",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645802,
+    "wof:lastmodified":1582382517,
     "wof:name":"Svidn\u00edk",
     "wof:parent_id":102080623,
     "wof:placetype":"locality",

--- a/data/101/780/863/101780863.geojson
+++ b/data/101/780/863/101780863.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Richnava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b33fc5b6fded3ecd8b11ac59f7b1e79",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":101780863,
-    "wof:lastmodified":1566645823,
+    "wof:lastmodified":1582382519,
     "wof:name":"Richnava",
     "wof:parent_id":102080559,
     "wof:placetype":"locality",

--- a/data/101/780/867/101780867.geojson
+++ b/data/101/780/867/101780867.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Papradno"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b0602679fa1445141bc2f6bad1a1fb3",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101780867,
-    "wof:lastmodified":1566645808,
+    "wof:lastmodified":1582382517,
     "wof:name":"Papradno",
     "wof:parent_id":102080575,
     "wof:placetype":"locality",

--- a/data/101/780/871/101780871.geojson
+++ b/data/101/780/871/101780871.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Trsten\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3ff2475d19457bd7d162819b8cec041",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101780871,
-    "wof:lastmodified":1566645818,
+    "wof:lastmodified":1582382518,
     "wof:name":"Trsten\u00e1",
     "wof:parent_id":102080605,
     "wof:placetype":"locality",

--- a/data/101/780/873/101780873.geojson
+++ b/data/101/780/873/101780873.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Star\u00e1 Bystrica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14cb16ed1f36f2e26d02bfc202fb84be",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101780873,
-    "wof:lastmodified":1566645803,
+    "wof:lastmodified":1582382517,
     "wof:name":"Star\u00e1 Bystrica",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/781/551/101781551.geojson
+++ b/data/101/781/551/101781551.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Mal\u00e1 Lehota"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81d96aa9c5e902d2bf008911ca018ad4",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101781551,
-    "wof:lastmodified":1566645776,
+    "wof:lastmodified":1582382514,
     "wof:name":"Mal\u00e1 Lehota",
     "wof:parent_id":102080499,
     "wof:placetype":"locality",

--- a/data/101/781/555/101781555.geojson
+++ b/data/101/781/555/101781555.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Hri\u0148ov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a371c75bfe37a78f7860edd203f72d7",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":101781555,
-    "wof:lastmodified":1566645781,
+    "wof:lastmodified":1582382514,
     "wof:name":"Hri\u0148ov\u00e1",
     "wof:parent_id":102080507,
     "wof:placetype":"locality",

--- a/data/101/781/559/101781559.geojson
+++ b/data/101/781/559/101781559.geojson
@@ -113,6 +113,9 @@
         "wk:page":"O\u010dov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35f3735d35c8fa29aafe4cb1b4ebc047",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101781559,
-    "wof:lastmodified":1566645776,
+    "wof:lastmodified":1582382514,
     "wof:name":"O\u010dov\u00e1",
     "wof:parent_id":102080509,
     "wof:placetype":"locality",

--- a/data/101/781/571/101781571.geojson
+++ b/data/101/781/571/101781571.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Vrbovce, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dce1ea36c7cd8ac99f5243e339f94b45",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101781571,
-    "wof:lastmodified":1566645785,
+    "wof:lastmodified":1582382515,
     "wof:name":"Vrbovce",
     "wof:parent_id":102080515,
     "wof:placetype":"locality",

--- a/data/101/781/575/101781575.geojson
+++ b/data/101/781/575/101781575.geojson
@@ -156,6 +156,9 @@
         "wd:id":"Q837460"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb74349b5cf8d88660932f4dc0a98c44",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645780,
+    "wof:lastmodified":1582382514,
     "wof:name":"Myjava",
     "wof:parent_id":102080515,
     "wof:placetype":"locality",

--- a/data/101/781/579/101781579.geojson
+++ b/data/101/781/579/101781579.geojson
@@ -196,6 +196,9 @@
         "wk:page":"Skalica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ccc56fce4a4cd385edaca2a1bc5d66bd",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645786,
+    "wof:lastmodified":1582382515,
     "wof:name":"Skalica",
     "wof:parent_id":102080517,
     "wof:placetype":"locality",

--- a/data/101/781/583/101781583.geojson
+++ b/data/101/781/583/101781583.geojson
@@ -128,6 +128,9 @@
         "qs_pg:id":190926
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6896813464785c074a710ff578c5285e",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101781583,
-    "wof:lastmodified":1566645787,
+    "wof:lastmodified":1582382515,
     "wof:name":"Kop\u010dany",
     "wof:parent_id":102080517,
     "wof:placetype":"locality",

--- a/data/101/781/587/101781587.geojson
+++ b/data/101/781/587/101781587.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Hol\u00ed\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96e1dff420775ec84ae65a180e1a1277",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645780,
+    "wof:lastmodified":1582382514,
     "wof:name":"Hol\u00ed\u010d",
     "wof:parent_id":102080517,
     "wof:placetype":"locality",

--- a/data/101/781/591/101781591.geojson
+++ b/data/101/781/591/101781591.geojson
@@ -183,6 +183,9 @@
         "wk:page":"Kremnica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0fdd9e9f9abbc37f73d60ad536da9f4e",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":101781591,
-    "wof:lastmodified":1566645783,
+    "wof:lastmodified":1582382514,
     "wof:name":"Kremnica",
     "wof:parent_id":102080519,
     "wof:placetype":"locality",

--- a/data/101/781/609/101781609.geojson
+++ b/data/101/781/609/101781609.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Lubina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6826e829c6faa13785a85a0ccb65e088",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101781609,
-    "wof:lastmodified":1566645785,
+    "wof:lastmodified":1582382515,
     "wof:name":"Lubina",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/781/613/101781613.geojson
+++ b/data/101/781/613/101781613.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Star\u00e1 Tur\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4489b812f1bd2bd3c9cc2f225012b5bc",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101781613,
-    "wof:lastmodified":1566645783,
+    "wof:lastmodified":1582382514,
     "wof:name":"Star\u00e1 Tur\u00e1",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/781/615/101781615.geojson
+++ b/data/101/781/615/101781615.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Bzince pod Javorinou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e48bab0088d452e98e8d1126a686c33",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101781615,
-    "wof:lastmodified":1566645784,
+    "wof:lastmodified":1582382514,
     "wof:name":"Bzince pod Javorinou",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/781/619/101781619.geojson
+++ b/data/101/781/619/101781619.geojson
@@ -180,6 +180,9 @@
         "wk:page":"B\u00e1novce nad Bebravou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb88580cee4117e83dc6976a8056d40b",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":101781619,
-    "wof:lastmodified":1566645777,
+    "wof:lastmodified":1582382514,
     "wof:name":"B\u00e1novce nad Bebravou",
     "wof:parent_id":102080523,
     "wof:placetype":"locality",

--- a/data/101/781/627/101781627.geojson
+++ b/data/101/781/627/101781627.geojson
@@ -149,6 +149,9 @@
         "wk:page":"Uhrovec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2cd23c4fa8990918822e366636a16cfd",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":101781627,
-    "wof:lastmodified":1566645778,
+    "wof:lastmodified":1582382514,
     "wof:name":"Uhrovec",
     "wof:parent_id":102080523,
     "wof:placetype":"locality",

--- a/data/101/781/629/101781629.geojson
+++ b/data/101/781/629/101781629.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Rybany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4fdd2b3e1770988977c8b4fb1f46baf",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101781629,
-    "wof:lastmodified":1566645778,
+    "wof:lastmodified":1582382514,
     "wof:name":"Rybany",
     "wof:parent_id":102080523,
     "wof:placetype":"locality",

--- a/data/101/781/641/101781641.geojson
+++ b/data/101/781/641/101781641.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Tu\u017eina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e4daf88effc19c6d2471c9e55588d801",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101781641,
-    "wof:lastmodified":1566645784,
+    "wof:lastmodified":1582382515,
     "wof:name":"Tu\u017eina",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/781/643/101781643.geojson
+++ b/data/101/781/643/101781643.geojson
@@ -106,6 +106,9 @@
         "wk:page":"Poruba, Prievidza District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2024971fa25088fd21def7068ce8c62",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101781643,
-    "wof:lastmodified":1566645777,
+    "wof:lastmodified":1582382514,
     "wof:name":"Poruba",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/781/651/101781651.geojson
+++ b/data/101/781/651/101781651.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Kanianka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"40e99657cf99f9b9a775546a6ddfff77",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101781651,
-    "wof:lastmodified":1566645779,
+    "wof:lastmodified":1582382514,
     "wof:name":"Kanianka",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/781/661/101781661.geojson
+++ b/data/101/781/661/101781661.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Nitrianske Rudno"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e538249be7b61be55adc088fc674a48",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101781661,
-    "wof:lastmodified":1566645779,
+    "wof:lastmodified":1582382514,
     "wof:name":"Nitrianske Rudno",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/781/679/101781679.geojson
+++ b/data/101/781/679/101781679.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Diviacka Nov\u00e1 Ves"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52d38622164b6158a637fe2254ca3c63",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101781679,
-    "wof:lastmodified":1566645784,
+    "wof:lastmodified":1582382515,
     "wof:name":"Diviacka Nov\u00e1 Ves",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/781/695/101781695.geojson
+++ b/data/101/781/695/101781695.geojson
@@ -177,6 +177,9 @@
         "wk:page":"Handlov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"480586cc1a86798bd18aec688afed4fc",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":101781695,
-    "wof:lastmodified":1566645779,
+    "wof:lastmodified":1582382514,
     "wof:name":"Handlov\u00e1",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/781/713/101781713.geojson
+++ b/data/101/781/713/101781713.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Nem\u0161ov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c641aad223f98b83146b5af20635ac3e",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101781713,
-    "wof:lastmodified":1566645780,
+    "wof:lastmodified":1582382514,
     "wof:name":"Nem\u0161ov\u00e1",
     "wof:parent_id":102080541,
     "wof:placetype":"locality",

--- a/data/101/781/717/101781717.geojson
+++ b/data/101/781/717/101781717.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Tren\u010dianska Tepl\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64fd205ae9ae1c5693d70d84cf2d85ba",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101781717,
-    "wof:lastmodified":1566645786,
+    "wof:lastmodified":1582382515,
     "wof:name":"Tren\u010dianska Tepl\u00e1",
     "wof:parent_id":102080541,
     "wof:placetype":"locality",

--- a/data/101/781/721/101781721.geojson
+++ b/data/101/781/721/101781721.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Tren\u010dianske Teplice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"40ba798f789fa703591d9306b0a9190d",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101781721,
-    "wof:lastmodified":1566645786,
+    "wof:lastmodified":1582382515,
     "wof:name":"Tren\u010dianske Teplice",
     "wof:parent_id":102080541,
     "wof:placetype":"locality",

--- a/data/101/781/731/101781731.geojson
+++ b/data/101/781/731/101781731.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Soblahov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"893562ea05abfd2d60f7f2e5803f93b6",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101781731,
-    "wof:lastmodified":1566645777,
+    "wof:lastmodified":1582382514,
     "wof:name":"Soblahov",
     "wof:parent_id":102080541,
     "wof:placetype":"locality",

--- a/data/101/781/741/101781741.geojson
+++ b/data/101/781/741/101781741.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Polomka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa48f7ada86ee9edd896211e3c7c3dd0",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101781741,
-    "wof:lastmodified":1566645781,
+    "wof:lastmodified":1582382514,
     "wof:name":"Polomka",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/781/745/101781745.geojson
+++ b/data/101/781/745/101781745.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Z\u00e1vadka nad Hronom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c79ad2375dc07d085941227d1bac715d",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101781745,
-    "wof:lastmodified":1566645787,
+    "wof:lastmodified":1582382515,
     "wof:name":"Z\u00e1vadka nad Hronom",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/781/757/101781757.geojson
+++ b/data/101/781/757/101781757.geojson
@@ -122,6 +122,9 @@
         "wk:page":"\u010cierny Balog"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b6edccc6fae3e247cbd65c5438baec11",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101781757,
-    "wof:lastmodified":1566645782,
+    "wof:lastmodified":1582382514,
     "wof:name":"\u010cierny Balog",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/781/761/101781761.geojson
+++ b/data/101/781/761/101781761.geojson
@@ -174,6 +174,9 @@
         "wk:page":"Dubnica nad V\u00e1hom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6928a4e4b4c9f7ebd41a1686384c2f6d",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":101781761,
-    "wof:lastmodified":1566645783,
+    "wof:lastmodified":1582382514,
     "wof:name":"Dubnica nad V\u00e1hom",
     "wof:parent_id":102080555,
     "wof:placetype":"locality",

--- a/data/101/781/767/101781767.geojson
+++ b/data/101/781/767/101781767.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Ilava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1fcd55885207d189d11cab4d681faa5f",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101781767,
-    "wof:lastmodified":1566645781,
+    "wof:lastmodified":1582382514,
     "wof:name":"Ilava",
     "wof:parent_id":102080555,
     "wof:placetype":"locality",

--- a/data/101/781/781/101781781.geojson
+++ b/data/101/781/781/101781781.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Nov\u00e1 Dubnica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"abce53dc8eab10a676883175cadca6fa",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101781781,
-    "wof:lastmodified":1566645785,
+    "wof:lastmodified":1582382515,
     "wof:name":"Nov\u00e1 Dubnica",
     "wof:parent_id":102080555,
     "wof:placetype":"locality",

--- a/data/101/781/787/101781787.geojson
+++ b/data/101/781/787/101781787.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Budkovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2547d9564e32cf5e3aca767b0abea31",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101781787,
-    "wof:lastmodified":1566645786,
+    "wof:lastmodified":1582382515,
     "wof:name":"Budkovce",
     "wof:parent_id":102080563,
     "wof:placetype":"locality",

--- a/data/101/781/791/101781791.geojson
+++ b/data/101/781/791/101781791.geojson
@@ -122,6 +122,9 @@
         "qs_pg:id":1181750
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1dfd60932115528d166f04ee1a6a442f",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101781791,
-    "wof:lastmodified":1566645777,
+    "wof:lastmodified":1582382514,
     "wof:name":"Pavlovce nad Uhom",
     "wof:parent_id":102080563,
     "wof:placetype":"locality",

--- a/data/101/781/813/101781813.geojson
+++ b/data/101/781/813/101781813.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Bel\u00e1, \u017dilina District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"50cebe153d38dac62e31b30a4894e016",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645784,
+    "wof:lastmodified":1582382515,
     "wof:name":"Bel\u00e1",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/782/715/101782715.geojson
+++ b/data/101/782/715/101782715.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Pukanec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c792b759f5379eb7fc522b49e266a614",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101782715,
-    "wof:lastmodified":1566645749,
+    "wof:lastmodified":1582382511,
     "wof:name":"Pukanec",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/782/717/101782717.geojson
+++ b/data/101/782/717/101782717.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Madunice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbff1bff6b2b4c0b8132c00bd22496df",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782717,
-    "wof:lastmodified":1566645757,
+    "wof:lastmodified":1582382512,
     "wof:name":"Madunice",
     "wof:parent_id":102080481,
     "wof:placetype":"locality",

--- a/data/101/782/721/101782721.geojson
+++ b/data/101/782/721/101782721.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Trakovice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2550e9eb1fde0330d578736adf9bc874",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782721,
-    "wof:lastmodified":1566645756,
+    "wof:lastmodified":1582382512,
     "wof:name":"Trakovice",
     "wof:parent_id":102080481,
     "wof:placetype":"locality",

--- a/data/101/782/723/101782723.geojson
+++ b/data/101/782/723/101782723.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Hlohovec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"228acee5cf0aec1d3ebfe6983cfd71ff",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645749,
+    "wof:lastmodified":1582382511,
     "wof:name":"Hlohovec",
     "wof:parent_id":102080481,
     "wof:placetype":"locality",

--- a/data/101/782/725/101782725.geojson
+++ b/data/101/782/725/101782725.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Krupina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"67bdbf46f2a4054901aebf1106e81987",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645747,
+    "wof:lastmodified":1582382511,
     "wof:name":"Krupina",
     "wof:parent_id":102080483,
     "wof:placetype":"locality",

--- a/data/101/782/727/101782727.geojson
+++ b/data/101/782/727/101782727.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Z\u00e1vod, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76ff5f3b192e8b6d9637f5f73d99f295",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101782727,
-    "wof:lastmodified":1566645758,
+    "wof:lastmodified":1582382512,
     "wof:name":"Z\u00e1vod",
     "wof:parent_id":102080487,
     "wof:placetype":"locality",

--- a/data/101/782/729/101782729.geojson
+++ b/data/101/782/729/101782729.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Studienka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a86ad673f9a3021f1173a4b35a16de44",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101782729,
-    "wof:lastmodified":1566645758,
+    "wof:lastmodified":1582382512,
     "wof:name":"Studienka",
     "wof:parent_id":102080487,
     "wof:placetype":"locality",

--- a/data/101/782/733/101782733.geojson
+++ b/data/101/782/733/101782733.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Gajary"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7a89bd136e07b4a44fcb7e38e735093e",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":101782733,
-    "wof:lastmodified":1566645750,
+    "wof:lastmodified":1582382511,
     "wof:name":"Gajary",
     "wof:parent_id":102080487,
     "wof:placetype":"locality",

--- a/data/101/782/739/101782739.geojson
+++ b/data/101/782/739/101782739.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Doln\u00e1 Krup\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eda49f330af42804ba173adeae727732",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645742,
+    "wof:lastmodified":1582382511,
     "wof:name":"Doln\u00e1 Krup\u00e1",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/782/741/101782741.geojson
+++ b/data/101/782/741/101782741.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Jaslovsk\u00e9 Bohunice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04bd801b2cf4c662684ebc3a19903241",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645750,
+    "wof:lastmodified":1582382511,
     "wof:name":"Jaslovsk\u00e9 Bohunice",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/782/743/101782743.geojson
+++ b/data/101/782/743/101782743.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Boler\u00e1z"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73640f62272b58067e0675489eda9761",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645756,
+    "wof:lastmodified":1582382512,
     "wof:name":"Boler\u00e1z",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/782/745/101782745.geojson
+++ b/data/101/782/745/101782745.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Mal\u017eenice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5e0f532d5ce5b7044f69417c242c1d4",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645758,
+    "wof:lastmodified":1582382512,
     "wof:name":"Mal\u017eenice",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/782/749/101782749.geojson
+++ b/data/101/782/749/101782749.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Sv\u00e4t\u00fd Anton"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c56f6f1e96ecd8294593ce4185e2af7f",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":101782749,
-    "wof:lastmodified":1566645748,
+    "wof:lastmodified":1582382511,
     "wof:name":"Sv\u00e4t\u00fd Anton",
     "wof:parent_id":102080491,
     "wof:placetype":"locality",

--- a/data/101/782/761/101782761.geojson
+++ b/data/101/782/761/101782761.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Div\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c51f02a7047d2384d6f324f020947568",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101782761,
-    "wof:lastmodified":1566645751,
+    "wof:lastmodified":1582382511,
     "wof:name":"Div\u00edn",
     "wof:parent_id":102080497,
     "wof:placetype":"locality",

--- a/data/101/782/765/101782765.geojson
+++ b/data/101/782/765/101782765.geojson
@@ -210,6 +210,9 @@
         "wk:page":"Lu\u010denec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74e99269b03e370e8588f1ea766e9cb5",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645742,
+    "wof:lastmodified":1582382511,
     "wof:name":"Lu\u010denec",
     "wof:parent_id":102080497,
     "wof:placetype":"locality",

--- a/data/101/782/771/101782771.geojson
+++ b/data/101/782/771/101782771.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Soboti\u0161te"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d5734cd7be7b9a9092d52cc1d82dec3a",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782771,
-    "wof:lastmodified":1566645748,
+    "wof:lastmodified":1582382511,
     "wof:name":"Soboti\u0161te",
     "wof:parent_id":102080505,
     "wof:placetype":"locality",

--- a/data/101/782/775/101782775.geojson
+++ b/data/101/782/775/101782775.geojson
@@ -116,6 +116,9 @@
         "wk:page":"K\u00faty"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8512fd58938889c41fbcc3203d7af7a1",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782775,
-    "wof:lastmodified":1566645756,
+    "wof:lastmodified":1582382512,
     "wof:name":"K\u00faty",
     "wof:parent_id":102080505,
     "wof:placetype":"locality",

--- a/data/101/782/785/101782785.geojson
+++ b/data/101/782/785/101782785.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Slia\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4dc17033cf28aec591ff2046f2ce2963",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645748,
+    "wof:lastmodified":1582382511,
     "wof:name":"Slia\u010d",
     "wof:parent_id":102080509,
     "wof:placetype":"locality",

--- a/data/101/782/787/101782787.geojson
+++ b/data/101/782/787/101782787.geojson
@@ -305,6 +305,9 @@
         "wd:id":"Q11874"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8605eb98dcfdc395a2cb57f1f99e3eac",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645757,
+    "wof:lastmodified":1582382512,
     "wof:name":"Zvolen",
     "wof:parent_id":102080509,
     "wof:placetype":"locality",

--- a/data/101/782/793/101782793.geojson
+++ b/data/101/782/793/101782793.geojson
@@ -113,6 +113,9 @@
         "wk:page":"M\u00e1linec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21601b9e18a34d9734edc299e1f01159",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101782793,
-    "wof:lastmodified":1566645751,
+    "wof:lastmodified":1582382511,
     "wof:name":"M\u00e1linec",
     "wof:parent_id":102080513,
     "wof:placetype":"locality",

--- a/data/101/782/799/101782799.geojson
+++ b/data/101/782/799/101782799.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Kalinovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a4031f229443e405836ecbe80f0b81f",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101782799,
-    "wof:lastmodified":1566645741,
+    "wof:lastmodified":1582382511,
     "wof:name":"Kalinovo",
     "wof:parent_id":102080513,
     "wof:placetype":"locality",

--- a/data/101/782/803/101782803.geojson
+++ b/data/101/782/803/101782803.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Gbely"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f64107b1475e54a91427486a37b25482",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101782803,
-    "wof:lastmodified":1566645746,
+    "wof:lastmodified":1582382511,
     "wof:name":"Gbely",
     "wof:parent_id":102080517,
     "wof:placetype":"locality",

--- a/data/101/782/807/101782807.geojson
+++ b/data/101/782/807/101782807.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Brodsk\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cbdfa80689f7f9a7639b092813e5e68a",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101782807,
-    "wof:lastmodified":1566645754,
+    "wof:lastmodified":1582382512,
     "wof:name":"Brodsk\u00e9",
     "wof:parent_id":102080517,
     "wof:placetype":"locality",

--- a/data/101/782/813/101782813.geojson
+++ b/data/101/782/813/101782813.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Beckov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35a06306def9a55c965d72cd9c48f226",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101782813,
-    "wof:lastmodified":1566645754,
+    "wof:lastmodified":1582382512,
     "wof:name":"Beckov",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/782/815/101782815.geojson
+++ b/data/101/782/815/101782815.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Ko\u010dovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ab3cc180bb8043a42273e57339c8bd47",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101782815,
-    "wof:lastmodified":1566645753,
+    "wof:lastmodified":1582382512,
     "wof:name":"Ko\u010dovce",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/782/817/101782817.geojson
+++ b/data/101/782/817/101782817.geojson
@@ -130,6 +130,9 @@
         "wk:page":"\u010cachtice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b40945dcb4748a18168cd04a2c8ea9be",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":101782817,
-    "wof:lastmodified":1566645744,
+    "wof:lastmodified":1582382511,
     "wof:name":"\u010cachtice",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/782/821/101782821.geojson
+++ b/data/101/782/821/101782821.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Nov\u00e9 Mesto nad V\u00e1hom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a9435a03c40955987dc7976aa5a561f",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101782821,
-    "wof:lastmodified":1566645744,
+    "wof:lastmodified":1582382511,
     "wof:name":"Nov\u00e9 Mesto nad V\u00e1hom",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/782/823/101782823.geojson
+++ b/data/101/782/823/101782823.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Tisovec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"79544ef44535370bc6e135b805683d4e",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101782823,
-    "wof:lastmodified":1566645752,
+    "wof:lastmodified":1582382511,
     "wof:name":"Tisovec",
     "wof:parent_id":102080525,
     "wof:placetype":"locality",

--- a/data/101/782/837/101782837.geojson
+++ b/data/101/782/837/101782837.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Bad\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0010f861750e2c2530384a02e0b504e2",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101782837,
-    "wof:lastmodified":1566645755,
+    "wof:lastmodified":1582382512,
     "wof:name":"Bad\u00edn",
     "wof:parent_id":102080531,
     "wof:placetype":"locality",

--- a/data/101/782/843/101782843.geojson
+++ b/data/101/782/843/101782843.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Doln\u00e9 Vestenice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a7d244a562fc40d95f81f4fab510759d",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782843,
-    "wof:lastmodified":1566645745,
+    "wof:lastmodified":1582382511,
     "wof:name":"Doln\u00e9 Vestenice",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/782/853/101782853.geojson
+++ b/data/101/782/853/101782853.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Se\u010dovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e93598e9a31de4468d0be29e5c5e15ee",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101782853,
-    "wof:lastmodified":1566645755,
+    "wof:lastmodified":1582382512,
     "wof:name":"Se\u010dovce",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/782/855/101782855.geojson
+++ b/data/101/782/855/101782855.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Zempl\u00ednska Teplica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76eaff22f6e48054acac9d1ba080af81",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782855,
-    "wof:lastmodified":1566645755,
+    "wof:lastmodified":1582382512,
     "wof:name":"Zempl\u00ednska Teplica",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/782/857/101782857.geojson
+++ b/data/101/782/857/101782857.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Kuzmice, Trebi\u0161ov District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf8e25d3badfd8bfc462da781c935408",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782857,
-    "wof:lastmodified":1566645746,
+    "wof:lastmodified":1582382511,
     "wof:name":"Kuzmice",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/782/867/101782867.geojson
+++ b/data/101/782/867/101782867.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Leles"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8dd37e47297f69e6c6b528c89bffaa1b",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":101782867,
-    "wof:lastmodified":1566645747,
+    "wof:lastmodified":1582382511,
     "wof:name":"Leles",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/782/891/101782891.geojson
+++ b/data/101/782/891/101782891.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Kr\u00e1snohorsk\u00e9 Podhradie"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca21bb19ecf4f2b9d1fec5a08e33bfdd",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101782891,
-    "wof:lastmodified":1566645754,
+    "wof:lastmodified":1582382512,
     "wof:name":"Kr\u00e1snohorsk\u00e9 Podhradie",
     "wof:parent_id":102080553,
     "wof:placetype":"locality",

--- a/data/101/782/895/101782895.geojson
+++ b/data/101/782/895/101782895.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Ple\u0161ivec, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8cc2fffa235c12f3ee1a1b21a7e79f05",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782895,
-    "wof:lastmodified":1566645745,
+    "wof:lastmodified":1582382511,
     "wof:name":"Ple\u0161ivec",
     "wof:parent_id":102080553,
     "wof:placetype":"locality",

--- a/data/101/782/901/101782901.geojson
+++ b/data/101/782/901/101782901.geojson
@@ -178,6 +178,9 @@
         "wk:page":"Ro\u017e\u0148ava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c4b8feb11f8b74b66fef502abf044ec8",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645742,
+    "wof:lastmodified":1582382511,
     "wof:name":"Ro\u017e\u0148ava",
     "wof:parent_id":102080553,
     "wof:placetype":"locality",

--- a/data/101/782/911/101782911.geojson
+++ b/data/101/782/911/101782911.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Medzev"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4beedda77488da828450b09e82645202",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":101782911,
-    "wof:lastmodified":1566645756,
+    "wof:lastmodified":1582382512,
     "wof:name":"Medzev",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/782/913/101782913.geojson
+++ b/data/101/782/913/101782913.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Jasov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"84f81bf6275b59da2c9daf5ddc0d29e3",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101782913,
-    "wof:lastmodified":1566645750,
+    "wof:lastmodified":1582382511,
     "wof:name":"Jasov",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/782/923/101782923.geojson
+++ b/data/101/782/923/101782923.geojson
@@ -153,6 +153,9 @@
         "wk:page":"Moldava nad Bodvou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c14b5b39bc3cc751ebe99658db3e6576",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101782923,
-    "wof:lastmodified":1566645749,
+    "wof:lastmodified":1582382511,
     "wof:name":"Moldava nad Bodvou",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/782/925/101782925.geojson
+++ b/data/101/782/925/101782925.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Slanec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8a9181a96ba491233d54875eb86d0f5d",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101782925,
-    "wof:lastmodified":1566645750,
+    "wof:lastmodified":1582382511,
     "wof:name":"Slanec",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/782/931/101782931.geojson
+++ b/data/101/782/931/101782931.geojson
@@ -113,6 +113,9 @@
         "wk:page":"\u017dda\u0148a"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba326338e2209ca320dd2c16eda8d89d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101782931,
-    "wof:lastmodified":1566645741,
+    "wof:lastmodified":1582382511,
     "wof:name":"\u017dda\u0148a",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/782/933/101782933.geojson
+++ b/data/101/782/933/101782933.geojson
@@ -119,6 +119,9 @@
         "qs_pg:id":940111
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13f57b74548a3cda1875686c6fc7dda5",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101782933,
-    "wof:lastmodified":1566645752,
+    "wof:lastmodified":1582382511,
     "wof:name":"Trsten\u00e9 pri Horn\u00e1de",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/782/941/101782941.geojson
+++ b/data/101/782/941/101782941.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Smoln\u00edk"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"124c33fe4ac63f83a9b27f65b10779ac",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101782941,
-    "wof:lastmodified":1566645748,
+    "wof:lastmodified":1582382511,
     "wof:name":"Smoln\u00edk",
     "wof:parent_id":102080559,
     "wof:placetype":"locality",

--- a/data/101/783/947/101783947.geojson
+++ b/data/101/783/947/101783947.geojson
@@ -189,6 +189,9 @@
         "wk:page":"Galanta"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80f75fdefd00115c19dbd33dfa87478f",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
         }
     ],
     "wof:id":101783947,
-    "wof:lastmodified":1566645760,
+    "wof:lastmodified":1582382512,
     "wof:name":"Galanta",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/783/949/101783949.geojson
+++ b/data/101/783/949/101783949.geojson
@@ -193,6 +193,9 @@
         "wk:page":"Pezinok"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0dd60eefadf277d3c9ab7892221f00a0",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645760,
+    "wof:lastmodified":1582382512,
     "wof:name":"Pezinok",
     "wof:parent_id":102080471,
     "wof:placetype":"locality",

--- a/data/101/783/955/101783955.geojson
+++ b/data/101/783/955/101783955.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Jelenec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"214a23af759f4d5e94fce499de0bc9a8",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645759,
+    "wof:lastmodified":1582382512,
     "wof:name":"Jelenec",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/783/967/101783967.geojson
+++ b/data/101/783/967/101783967.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Tlma\u010de"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"61a93525d221036e9f73a75fd23f6302",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101783967,
-    "wof:lastmodified":1566645761,
+    "wof:lastmodified":1582382512,
     "wof:name":"Tlma\u010de",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/783/971/101783971.geojson
+++ b/data/101/783/971/101783971.geojson
@@ -110,6 +110,9 @@
         "wk:page":"B\u00e1tovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23fd4998a83872d2689dfc5f1b1242fe",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101783971,
-    "wof:lastmodified":1566645760,
+    "wof:lastmodified":1582382512,
     "wof:name":"B\u00e1tovce",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/783/977/101783977.geojson
+++ b/data/101/783/977/101783977.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Star\u00fd Tekov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad27132c9b1b3654946d94cef434a558",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101783977,
-    "wof:lastmodified":1566645759,
+    "wof:lastmodified":1582382512,
     "wof:name":"Star\u00fd Tekov",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/783/987/101783987.geojson
+++ b/data/101/783/987/101783987.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Demandice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4d14ff67b12c654740fbff2270ca3056",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101783987,
-    "wof:lastmodified":1566645761,
+    "wof:lastmodified":1582382512,
     "wof:name":"Demandice",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/783/989/101783989.geojson
+++ b/data/101/783/989/101783989.geojson
@@ -116,6 +116,9 @@
         "qs_pg:id":1012882
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9547e05c3b89028ebd0591c7228a0795",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101783989,
-    "wof:lastmodified":1566645761,
+    "wof:lastmodified":1582382512,
     "wof:name":"Dvorn\u00edky",
     "wof:parent_id":102080481,
     "wof:placetype":"locality",

--- a/data/101/784/009/101784009.geojson
+++ b/data/101/784/009/101784009.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Jakubov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6d545b741ae17151998e1b9899ab587",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101784009,
-    "wof:lastmodified":1566645765,
+    "wof:lastmodified":1582382513,
     "wof:name":"Jakubov",
     "wof:parent_id":102080487,
     "wof:placetype":"locality",

--- a/data/101/784/011/101784011.geojson
+++ b/data/101/784/011/101784011.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Kuchy\u0148a"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3acdd68116c92781464518845c3bea93",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101784011,
-    "wof:lastmodified":1566645769,
+    "wof:lastmodified":1582382513,
     "wof:name":"Kuchy\u0148a",
     "wof:parent_id":102080487,
     "wof:placetype":"locality",

--- a/data/101/784/013/101784013.geojson
+++ b/data/101/784/013/101784013.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Horn\u00e9 Ore\u0161any"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c53d0aa1566138129a81321557f0ea9d",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645764,
+    "wof:lastmodified":1582382512,
     "wof:name":"Horn\u00e9 Ore\u0161any",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/784/017/101784017.geojson
+++ b/data/101/784/017/101784017.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Doln\u00e9 Ore\u0161any"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"058b00332b46edeba5c3429c5de56e50",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645770,
+    "wof:lastmodified":1582382513,
     "wof:name":"Doln\u00e9 Ore\u0161any",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/784/025/101784025.geojson
+++ b/data/101/784/025/101784025.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Smolenice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"950842f227bd039df38458b1dfe9850f",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645764,
+    "wof:lastmodified":1582382512,
     "wof:name":"Smolenice",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/784/031/101784031.geojson
+++ b/data/101/784/031/101784031.geojson
@@ -159,6 +159,9 @@
         "wk:page":"Vrbov\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f12fd159b14243e644197d6412554b91",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":101784031,
-    "wof:lastmodified":1566645765,
+    "wof:lastmodified":1582382513,
     "wof:name":"Vrbov\u00e9",
     "wof:parent_id":102080495,
     "wof:placetype":"locality",

--- a/data/101/784/035/101784035.geojson
+++ b/data/101/784/035/101784035.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Krakovany, Pie\u0161\u0165any District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ee2cf77a34927dba41489d1e892048f7",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101784035,
-    "wof:lastmodified":1566645770,
+    "wof:lastmodified":1582382513,
     "wof:name":"Krakovany",
     "wof:parent_id":102080495,
     "wof:placetype":"locality",

--- a/data/101/784/039/101784039.geojson
+++ b/data/101/784/039/101784039.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Vesel\u00e9, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6f0435760e1e2eb32940ab8eb56dd18",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101784039,
-    "wof:lastmodified":1566645767,
+    "wof:lastmodified":1582382513,
     "wof:name":"Vesel\u00e9",
     "wof:parent_id":102080495,
     "wof:placetype":"locality",

--- a/data/101/784/043/101784043.geojson
+++ b/data/101/784/043/101784043.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Drahovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"330f34eb3098e817a75a70897a350c90",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101784043,
-    "wof:lastmodified":1566645770,
+    "wof:lastmodified":1582382513,
     "wof:name":"Drahovce",
     "wof:parent_id":102080495,
     "wof:placetype":"locality",

--- a/data/101/784/053/101784053.geojson
+++ b/data/101/784/053/101784053.geojson
@@ -116,6 +116,9 @@
         "qs_pg:id":884323
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3e1da88e48ec935b11f27ecedc5c2392",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101784053,
-    "wof:lastmodified":1566645765,
+    "wof:lastmodified":1582382513,
     "wof:name":"Tekovsk\u00e1 Breznica",
     "wof:parent_id":102080499,
     "wof:placetype":"locality",

--- a/data/101/784/057/101784057.geojson
+++ b/data/101/784/057/101784057.geojson
@@ -119,6 +119,9 @@
         "qs_pg:id":1271477
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a69d4c045f15e170eddde058824e5dc4",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101784057,
-    "wof:lastmodified":1566645771,
+    "wof:lastmodified":1582382513,
     "wof:name":"Nitrianska Blatnica",
     "wof:parent_id":102080501,
     "wof:placetype":"locality",

--- a/data/101/784/061/101784061.geojson
+++ b/data/101/784/061/101784061.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Kru\u0161ovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"91b2f7718a47630b6eb25207e9c3a0c9",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101784061,
-    "wof:lastmodified":1566645771,
+    "wof:lastmodified":1582382513,
     "wof:name":"Kru\u0161ovce",
     "wof:parent_id":102080501,
     "wof:placetype":"locality",

--- a/data/101/784/063/101784063.geojson
+++ b/data/101/784/063/101784063.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Bojn\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bfca887a5d75854d25744c1541756c24",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101784063,
-    "wof:lastmodified":1566645766,
+    "wof:lastmodified":1582382513,
     "wof:name":"Bojn\u00e1",
     "wof:parent_id":102080501,
     "wof:placetype":"locality",

--- a/data/101/784/075/101784075.geojson
+++ b/data/101/784/075/101784075.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Ludanice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfa3274328c3af662246a8ae9d88abfa",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101784075,
-    "wof:lastmodified":1566645770,
+    "wof:lastmodified":1582382513,
     "wof:name":"Ludanice",
     "wof:parent_id":102080501,
     "wof:placetype":"locality",

--- a/data/101/784/083/101784083.geojson
+++ b/data/101/784/083/101784083.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Kl\u00e1tova Nov\u00e1 Ves"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"116f469312fad8f1ceaee465e8fd4e3d",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101784083,
-    "wof:lastmodified":1566645764,
+    "wof:lastmodified":1582382512,
     "wof:name":"Kl\u00e1tova Nov\u00e1 Ves",
     "wof:parent_id":102080503,
     "wof:placetype":"locality",

--- a/data/101/784/085/101784085.geojson
+++ b/data/101/784/085/101784085.geojson
@@ -180,6 +180,9 @@
         "wk:page":"Partiz\u00e1nske"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e5c58fbdee55d9489bc395402af391a1",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":101784085,
-    "wof:lastmodified":1566645764,
+    "wof:lastmodified":1582382512,
     "wof:name":"Partiz\u00e1nske",
     "wof:parent_id":102080503,
     "wof:placetype":"locality",

--- a/data/101/784/089/101784089.geojson
+++ b/data/101/784/089/101784089.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Bo\u0161any"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46978cbf0de25e1c422e1728f7ec1a4e",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101784089,
-    "wof:lastmodified":1566645769,
+    "wof:lastmodified":1582382513,
     "wof:name":"Bo\u0161any",
     "wof:parent_id":102080503,
     "wof:placetype":"locality",

--- a/data/101/784/095/101784095.geojson
+++ b/data/101/784/095/101784095.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Jablonica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b58b4961f00255761ef8fd8f375d60f3",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101784095,
-    "wof:lastmodified":1566645771,
+    "wof:lastmodified":1582382513,
     "wof:name":"Jablonica",
     "wof:parent_id":102080505,
     "wof:placetype":"locality",

--- a/data/101/784/097/101784097.geojson
+++ b/data/101/784/097/101784097.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Lak\u0161\u00e1rska Nov\u00e1 Ves"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7e3290b8aeccbc95aef43983f88efad6",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101784097,
-    "wof:lastmodified":1566645766,
+    "wof:lastmodified":1582382513,
     "wof:name":"Lak\u0161\u00e1rska Nov\u00e1 Ves",
     "wof:parent_id":102080505,
     "wof:placetype":"locality",

--- a/data/101/784/101/101784101.geojson
+++ b/data/101/784/101/101784101.geojson
@@ -175,6 +175,9 @@
         "wk:page":"Senica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2c891367ecc001ae47c0c12df2e8de3",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645769,
+    "wof:lastmodified":1582382513,
     "wof:name":"Senica",
     "wof:parent_id":102080505,
     "wof:placetype":"locality",

--- a/data/101/784/103/101784103.geojson
+++ b/data/101/784/103/101784103.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Zvolensk\u00e1 Slatina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d95dac5c48e7f07ee6785127560a5d2",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101784103,
-    "wof:lastmodified":1566645762,
+    "wof:lastmodified":1582382512,
     "wof:name":"Zvolensk\u00e1 Slatina",
     "wof:parent_id":102080509,
     "wof:placetype":"locality",

--- a/data/101/784/107/101784107.geojson
+++ b/data/101/784/107/101784107.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Dobr\u00e1 Niva"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"36f0501596cdf1f89c3d166eb76dfe2f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101784107,
-    "wof:lastmodified":1566645768,
+    "wof:lastmodified":1582382513,
     "wof:name":"Dobr\u00e1 Niva",
     "wof:parent_id":102080509,
     "wof:placetype":"locality",

--- a/data/101/784/109/101784109.geojson
+++ b/data/101/784/109/101784109.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Plie\u0161ovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37bc4a5abefdd7dd80519063c6967d6f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101784109,
-    "wof:lastmodified":1566645768,
+    "wof:lastmodified":1582382513,
     "wof:name":"Plie\u0161ovce",
     "wof:parent_id":102080509,
     "wof:placetype":"locality",

--- a/data/101/784/111/101784111.geojson
+++ b/data/101/784/111/101784111.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Brezov\u00e1 pod Bradlom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"492f7b7a6fffd2ab029339ee35157ed9",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":101784111,
-    "wof:lastmodified":1566645767,
+    "wof:lastmodified":1582382513,
     "wof:name":"Brezov\u00e1 pod Bradlom",
     "wof:parent_id":102080515,
     "wof:placetype":"locality",

--- a/data/101/784/115/101784115.geojson
+++ b/data/101/784/115/101784115.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Podolie"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2ab590e62259ea133ae9b6e0dd2f848",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101784115,
-    "wof:lastmodified":1566645772,
+    "wof:lastmodified":1582382513,
     "wof:name":"Podolie",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/784/117/101784117.geojson
+++ b/data/101/784/117/101784117.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Horn\u00e1 Streda"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a62cb089569390db81baac55b51a9abf",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101784117,
-    "wof:lastmodified":1566645768,
+    "wof:lastmodified":1582382513,
     "wof:name":"Horn\u00e1 Streda",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/784/119/101784119.geojson
+++ b/data/101/784/119/101784119.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Pobedim"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"06766ed3218d0bb1dc4a4d53a47524c3",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101784119,
-    "wof:lastmodified":1566645768,
+    "wof:lastmodified":1582382513,
     "wof:name":"Pobedim",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/784/127/101784127.geojson
+++ b/data/101/784/127/101784127.geojson
@@ -116,6 +116,9 @@
         "qs_pg:id":255569
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99f575950b255cd8bf536423273b2e01",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101784127,
-    "wof:lastmodified":1566645767,
+    "wof:lastmodified":1582382513,
     "wof:name":"Rimavsk\u00e9 Janovce",
     "wof:parent_id":102080525,
     "wof:placetype":"locality",

--- a/data/101/784/131/101784131.geojson
+++ b/data/101/784/131/101784131.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Rimavsk\u00e1 Se\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c6824f548faf1d3d7253cf199c2c92b",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101784131,
-    "wof:lastmodified":1566645768,
+    "wof:lastmodified":1582382513,
     "wof:name":"Rimavsk\u00e1 Se\u010d",
     "wof:parent_id":102080525,
     "wof:placetype":"locality",

--- a/data/101/784/139/101784139.geojson
+++ b/data/101/784/139/101784139.geojson
@@ -110,6 +110,9 @@
         "wk:page":"\u010cere\u0148any"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"446857555569aa6976f3b97ff10cf97a",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101784139,
-    "wof:lastmodified":1566645768,
+    "wof:lastmodified":1582382513,
     "wof:name":"\u010cere\u0148any",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/784/143/101784143.geojson
+++ b/data/101/784/143/101784143.geojson
@@ -115,6 +115,9 @@
         "wd:id":"Q973842"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98c02478f40597e5ad872e0f52365b97",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101784143,
-    "wof:lastmodified":1566645767,
+    "wof:lastmodified":1582382513,
     "wof:name":"Oslany",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/784/145/101784145.geojson
+++ b/data/101/784/145/101784145.geojson
@@ -92,6 +92,9 @@
         "qs_pg:id":1332147
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0d31f2f76fc9ba7ccc312eef187253e",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101784145,
-    "wof:lastmodified":1566645767,
+    "wof:lastmodified":1582382513,
     "wof:name":"Horn\u00e1 Ves",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/785/169/101785169.geojson
+++ b/data/101/785/169/101785169.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Tr\u00e1vnica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"77b684f5267cd9e8b1b2859aee761873",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101785169,
-    "wof:lastmodified":1566645731,
+    "wof:lastmodified":1582382510,
     "wof:name":"Tr\u00e1vnica",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/785/177/101785177.geojson
+++ b/data/101/785/177/101785177.geojson
@@ -110,6 +110,9 @@
         "wk:page":"B\u00e1ho\u0148"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e3fb2c2ed41b11ca7bfd0a89e68e31a",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101785177,
-    "wof:lastmodified":1566645740,
+    "wof:lastmodified":1582382511,
     "wof:name":"B\u00e1ho\u0148",
     "wof:parent_id":102080471,
     "wof:placetype":"locality",

--- a/data/101/785/193/101785193.geojson
+++ b/data/101/785/193/101785193.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Pata, Galanta District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c24cdee71a33dafbc88c4db745a274e6",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101785193,
-    "wof:lastmodified":1566645731,
+    "wof:lastmodified":1582382510,
     "wof:name":"Pata",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/785/205/101785205.geojson
+++ b/data/101/785/205/101785205.geojson
@@ -113,6 +113,9 @@
         "wk:page":"\u010cast\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"24b6d80d5ab50b56f0468054e3f76ba4",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101785205,
-    "wof:lastmodified":1566645734,
+    "wof:lastmodified":1582382510,
     "wof:name":"\u010cast\u00e1",
     "wof:parent_id":102080471,
     "wof:placetype":"locality",

--- a/data/101/785/207/101785207.geojson
+++ b/data/101/785/207/101785207.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Budmerice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a99574d4cd4b5ec1e31092452cfb5ce",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101785207,
-    "wof:lastmodified":1566645738,
+    "wof:lastmodified":1582382510,
     "wof:name":"Budmerice",
     "wof:parent_id":102080471,
     "wof:placetype":"locality",

--- a/data/101/785/209/101785209.geojson
+++ b/data/101/785/209/101785209.geojson
@@ -183,6 +183,9 @@
         "wk:page":"Modra"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"929f368ff85de7492c9240846d51b2b6",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":101785209,
-    "wof:lastmodified":1566645738,
+    "wof:lastmodified":1582382510,
     "wof:name":"Modra",
     "wof:parent_id":102080471,
     "wof:placetype":"locality",

--- a/data/101/785/215/101785215.geojson
+++ b/data/101/785/215/101785215.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Vini\u010dn\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9eae118a0b7050efa54124e138dfb4dc",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101785215,
-    "wof:lastmodified":1566645736,
+    "wof:lastmodified":1582382510,
     "wof:name":"Vini\u010dn\u00e9",
     "wof:parent_id":102080471,
     "wof:placetype":"locality",

--- a/data/101/785/217/101785217.geojson
+++ b/data/101/785/217/101785217.geojson
@@ -187,6 +187,9 @@
         "wk:page":"Sv\u00e4t\u00fd Jur"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f37a4223a74f760009c6e0894bc2f3e7",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
         }
     ],
     "wof:id":101785217,
-    "wof:lastmodified":1566645732,
+    "wof:lastmodified":1582382510,
     "wof:name":"Sv\u00e4t\u00fd Jur",
     "wof:parent_id":102080471,
     "wof:placetype":"locality",

--- a/data/101/785/219/101785219.geojson
+++ b/data/101/785/219/101785219.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Slovensk\u00fd Grob"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aba2cbe921b17ee0973211db84524663",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101785219,
-    "wof:lastmodified":1566645732,
+    "wof:lastmodified":1582382510,
     "wof:name":"Slovensk\u00fd Grob",
     "wof:parent_id":102080471,
     "wof:placetype":"locality",

--- a/data/101/785/225/101785225.geojson
+++ b/data/101/785/225/101785225.geojson
@@ -111,6 +111,9 @@
         "qs_pg:id":388320
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fbce55416262c3d7185b57154fd8c3b",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645737,
+    "wof:lastmodified":1582382510,
     "wof:name":"Jarok",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/785/229/101785229.geojson
+++ b/data/101/785/229/101785229.geojson
@@ -115,6 +115,9 @@
         "wk:page":"\u010cechynce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d29fcb3b72b58983fa1edfd936a15dce",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645731,
+    "wof:lastmodified":1582382510,
     "wof:name":"\u010cechynce",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/785/251/101785251.geojson
+++ b/data/101/785/251/101785251.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Vr\u00e1ble"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f313a0358878ddf08c0a7676119e59de",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101785251,
-    "wof:lastmodified":1566645734,
+    "wof:lastmodified":1582382510,
     "wof:name":"Vr\u00e1ble",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/785/259/101785259.geojson
+++ b/data/101/785/259/101785259.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Doln\u00e1 Strehov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5bc3dfbd0707af5215bc941eb67683d2",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101785259,
-    "wof:lastmodified":1566645733,
+    "wof:lastmodified":1582382510,
     "wof:name":"Doln\u00e1 Strehov\u00e1",
     "wof:parent_id":102080479,
     "wof:placetype":"locality",

--- a/data/101/785/261/101785261.geojson
+++ b/data/101/785/261/101785261.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Modr\u00fd Kame\u0148"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3fdbaf7a3126f56cba5657f0c5a34c6",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":101785261,
-    "wof:lastmodified":1566645733,
+    "wof:lastmodified":1582382510,
     "wof:name":"Modr\u00fd Kame\u0148",
     "wof:parent_id":102080479,
     "wof:placetype":"locality",

--- a/data/101/785/265/101785265.geojson
+++ b/data/101/785/265/101785265.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Vinica, Ve\u013ek\u00fd Krt\u00ed\u0161 District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae25b954a9005eb74521850b78a176cc",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101785265,
-    "wof:lastmodified":1566645739,
+    "wof:lastmodified":1582382510,
     "wof:name":"Vinica",
     "wof:parent_id":102080479,
     "wof:placetype":"locality",

--- a/data/101/785/283/101785283.geojson
+++ b/data/101/785/283/101785283.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Zohor"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9669320623a68d7e57b04b356376226",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":101785283,
-    "wof:lastmodified":1566645736,
+    "wof:lastmodified":1582382510,
     "wof:name":"Zohor",
     "wof:parent_id":102080487,
     "wof:placetype":"locality",

--- a/data/101/785/289/101785289.geojson
+++ b/data/101/785/289/101785289.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Stupava, Malacky District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d13d41f4ad504f93d116863aa137afda",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":101785289,
-    "wof:lastmodified":1566645732,
+    "wof:lastmodified":1582382510,
     "wof:name":"Stupava",
     "wof:parent_id":102080487,
     "wof:placetype":"locality",

--- a/data/101/785/291/101785291.geojson
+++ b/data/101/785/291/101785291.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Such\u00e1 nad Parnou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f2b7150eb7130e57ee7da3a6a3ab84c",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645738,
+    "wof:lastmodified":1582382510,
     "wof:name":"Such\u00e1 nad Parnou",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/785/295/101785295.geojson
+++ b/data/101/785/295/101785295.geojson
@@ -121,6 +121,9 @@
         "wk:page":"Ru\u017eindol"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b216fe7262de7d972e350e637771aa8b",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645733,
+    "wof:lastmodified":1582382510,
     "wof:name":"Ru\u017eindol",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/785/297/101785297.geojson
+++ b/data/101/785/297/101785297.geojson
@@ -118,6 +118,9 @@
         "woe:id":818613
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd0792b14e02fe61dd481e765d281c80",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645739,
+    "wof:lastmodified":1582382510,
     "wof:name":"Biely Kostol",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/785/299/101785299.geojson
+++ b/data/101/785/299/101785299.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Zavar"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c8acdd3cc3d867fca9ede91082654948",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645740,
+    "wof:lastmodified":1582382511,
     "wof:name":"Zavar",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/785/305/101785305.geojson
+++ b/data/101/785/305/101785305.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Voderady"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9aabe54047b4388822aeabe66f9bf4c",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645736,
+    "wof:lastmodified":1582382510,
     "wof:name":"Voderady",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/786/305/101786305.geojson
+++ b/data/101/786/305/101786305.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Baj\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9c3710cdc13ed7cc248b84dc1e23c52",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101786305,
-    "wof:lastmodified":1566645792,
+    "wof:lastmodified":1582382516,
     "wof:name":"Baj\u010d",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/101/786/313/101786313.geojson
+++ b/data/101/786/313/101786313.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Orechov\u00e1 Pot\u00f4\u0148"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5fba39e60314832169b7cef25098bbb",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101786313,
-    "wof:lastmodified":1566645791,
+    "wof:lastmodified":1582382515,
     "wof:name":"Orechov\u00e1 Pot\u00f4\u0148",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/786/315/101786315.geojson
+++ b/data/101/786/315/101786315.geojson
@@ -187,6 +187,9 @@
         "wk:page":"Dunajsk\u00e1 Streda"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"afb5dd7189f7d5fba4cdc3876d2b259c",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645790,
+    "wof:lastmodified":1582382515,
     "wof:name":"Dunajsk\u00e1 Streda",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/786/323/101786323.geojson
+++ b/data/101/786/323/101786323.geojson
@@ -180,6 +180,9 @@
         "wk:page":"\u0160amor\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8120d82a9526bfc80a6d89f4f2af9957",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":101786323,
-    "wof:lastmodified":1566645790,
+    "wof:lastmodified":1582382515,
     "wof:name":"\u0160amor\u00edn",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/786/327/101786327.geojson
+++ b/data/101/786/327/101786327.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Pal\u00e1rikovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae00fdf08083a60544e9e5fd6c3e69a4",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101786327,
-    "wof:lastmodified":1566645793,
+    "wof:lastmodified":1582382516,
     "wof:name":"Pal\u00e1rikovo",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/331/101786331.geojson
+++ b/data/101/786/331/101786331.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Dvory nad \u017ditavou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c581fd1929bd3f8b8fbb8264ebf403ab",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101786331,
-    "wof:lastmodified":1566645787,
+    "wof:lastmodified":1582382515,
     "wof:name":"Dvory nad \u017ditavou",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/335/101786335.geojson
+++ b/data/101/786/335/101786335.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Dubn\u00edk"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"125263a221a3e76a20ec2277c02cafdd",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101786335,
-    "wof:lastmodified":1566645791,
+    "wof:lastmodified":1582382515,
     "wof:name":"Dubn\u00edk",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/339/101786339.geojson
+++ b/data/101/786/339/101786339.geojson
@@ -203,6 +203,9 @@
         "wd:id":"Q276362"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0eeee1364c0c873f5e7cdfdf0478bd5",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":101786339,
-    "wof:lastmodified":1566645788,
+    "wof:lastmodified":1582382515,
     "wof:name":"Nov\u00e9 Z\u00e1mky",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/343/101786343.geojson
+++ b/data/101/786/343/101786343.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Svod\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"da9918f06028a02ce3b6b72e025d31e9",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101786343,
-    "wof:lastmodified":1566645795,
+    "wof:lastmodified":1582382516,
     "wof:name":"Svod\u00edn",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/347/101786347.geojson
+++ b/data/101/786/347/101786347.geojson
@@ -133,6 +133,9 @@
         "qs_pg:id":905014
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c77a32ccfd6889157e82e0a0e8c779e9",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101786347,
-    "wof:lastmodified":1566645790,
+    "wof:lastmodified":1582382515,
     "wof:name":"Lipov\u00e1",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/353/101786353.geojson
+++ b/data/101/786/353/101786353.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Podh\u00e1jska"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9702a7d83a70964da0ad9dfbaaecb50",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101786353,
-    "wof:lastmodified":1566645788,
+    "wof:lastmodified":1582382515,
     "wof:name":"Podh\u00e1jska",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/359/101786359.geojson
+++ b/data/101/786/359/101786359.geojson
@@ -113,6 +113,9 @@
         "wk:page":"B\u00e1nov, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aadfb064c1185903e01adf494672ce00",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101786359,
-    "wof:lastmodified":1566645791,
+    "wof:lastmodified":1582382515,
     "wof:name":"B\u00e1nov",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/361/101786361.geojson
+++ b/data/101/786/361/101786361.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Be\u0161e\u0148ov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ffe494d99fab35ef42c1327b82b14cd0",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101786361,
-    "wof:lastmodified":1566645791,
+    "wof:lastmodified":1582382515,
     "wof:name":"Be\u0161e\u0148ov",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/365/101786365.geojson
+++ b/data/101/786/365/101786365.geojson
@@ -174,6 +174,9 @@
         "wk:page":"\u0160urany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1a8a9046d5a314b3c24f3c9dd607ff1",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":101786365,
-    "wof:lastmodified":1566645788,
+    "wof:lastmodified":1582382515,
     "wof:name":"\u0160urany",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/786/369/101786369.geojson
+++ b/data/101/786/369/101786369.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Malinovo, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c0b99006004d617bd18e0535c8e6235b",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101786369,
-    "wof:lastmodified":1566645791,
+    "wof:lastmodified":1582382516,
     "wof:name":"Malinovo",
     "wof:parent_id":102080465,
     "wof:placetype":"locality",

--- a/data/101/786/371/101786371.geojson
+++ b/data/101/786/371/101786371.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Tom\u00e1\u0161ov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63ccca778aa3ba0d1a71ee4219e6a543",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101786371,
-    "wof:lastmodified":1566645790,
+    "wof:lastmodified":1582382515,
     "wof:name":"Tom\u00e1\u0161ov",
     "wof:parent_id":102080465,
     "wof:placetype":"locality",

--- a/data/101/786/383/101786383.geojson
+++ b/data/101/786/383/101786383.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Te\u0161ed\u00edkovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7eade219568278bbcc4e931980786d37",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101786383,
-    "wof:lastmodified":1566645790,
+    "wof:lastmodified":1582382515,
     "wof:name":"Te\u0161ed\u00edkovo",
     "wof:parent_id":102080467,
     "wof:placetype":"locality",

--- a/data/101/786/385/101786385.geojson
+++ b/data/101/786/385/101786385.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Selice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec1e132a7937c3151bda8180f2d1d35a",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101786385,
-    "wof:lastmodified":1566645790,
+    "wof:lastmodified":1582382515,
     "wof:name":"Selice",
     "wof:parent_id":102080467,
     "wof:placetype":"locality",

--- a/data/101/786/387/101786387.geojson
+++ b/data/101/786/387/101786387.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Diakovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa840e6dbb41ed00d3f797f9415c61e1",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101786387,
-    "wof:lastmodified":1566645794,
+    "wof:lastmodified":1582382516,
     "wof:name":"Diakovce",
     "wof:parent_id":102080467,
     "wof:placetype":"locality",

--- a/data/101/786/389/101786389.geojson
+++ b/data/101/786/389/101786389.geojson
@@ -113,6 +113,9 @@
         "wk:page":"\u017dih\u00e1rec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"305ba172553a325390f4ff1f69e44b8b",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101786389,
-    "wof:lastmodified":1566645794,
+    "wof:lastmodified":1582382516,
     "wof:name":"\u017dih\u00e1rec",
     "wof:parent_id":102080467,
     "wof:placetype":"locality",

--- a/data/101/786/393/101786393.geojson
+++ b/data/101/786/393/101786393.geojson
@@ -191,6 +191,9 @@
         "wk:page":"\u0160a\u013ea"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8a2b37ec55547d51a8679564ad3959d8",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645792,
+    "wof:lastmodified":1582382516,
     "wof:name":"\u0160a\u013ea",
     "wof:parent_id":102080467,
     "wof:placetype":"locality",

--- a/data/101/786/395/101786395.geojson
+++ b/data/101/786/395/101786395.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Tom\u00e1\u0161ikovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b0e1976a8c40d4fed15af86da3d0020d",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101786395,
-    "wof:lastmodified":1566645791,
+    "wof:lastmodified":1582382515,
     "wof:name":"Tom\u00e1\u0161ikovo",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/786/403/101786403.geojson
+++ b/data/101/786/403/101786403.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Mat\u00fa\u0161kovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fb6dfcc1c9c70f03590092b4e7da3013",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101786403,
-    "wof:lastmodified":1566645793,
+    "wof:lastmodified":1582382516,
     "wof:name":"Mat\u00fa\u0161kovo",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/786/405/101786405.geojson
+++ b/data/101/786/405/101786405.geojson
@@ -113,6 +113,9 @@
         "wk:page":"\u010cierna Voda"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"24030a5dee9a79b56a4bd608b313f0e5",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101786405,
-    "wof:lastmodified":1566645793,
+    "wof:lastmodified":1582382516,
     "wof:name":"\u010cierna Voda",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/786/407/101786407.geojson
+++ b/data/101/786/407/101786407.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Horn\u00e9 Saliby"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db3e6b4c57e97a06ca5ae35db173e29b",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101786407,
-    "wof:lastmodified":1566645789,
+    "wof:lastmodified":1582382515,
     "wof:name":"Horn\u00e9 Saliby",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/786/413/101786413.geojson
+++ b/data/101/786/413/101786413.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Jelka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f02d297c4b8da88fda4eb138ca2fe2f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101786413,
-    "wof:lastmodified":1566645789,
+    "wof:lastmodified":1582382515,
     "wof:name":"Jelka",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/786/421/101786421.geojson
+++ b/data/101/786/421/101786421.geojson
@@ -165,6 +165,9 @@
         "qs_pg:id":1153002
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6db05bfb826e8b81fde8650945d35bd",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":101786421,
-    "wof:lastmodified":1566645792,
+    "wof:lastmodified":1582382516,
     "wof:name":"\u0160ahy",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/786/423/101786423.geojson
+++ b/data/101/786/423/101786423.geojson
@@ -162,6 +162,9 @@
         "wk:page":"\u017deliezovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3a312f5961ac4c6ff4fe4725bda19c27",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101786423,
-    "wof:lastmodified":1566645789,
+    "wof:lastmodified":1582382515,
     "wof:name":"\u017deliezovce",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/786/425/101786425.geojson
+++ b/data/101/786/425/101786425.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Farn\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a410f19171b18c674d2c0c6c97017208",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101786425,
-    "wof:lastmodified":1566645789,
+    "wof:lastmodified":1582382515,
     "wof:name":"Farn\u00e1",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/787/461/101787461.geojson
+++ b/data/101/787/461/101787461.geojson
@@ -110,6 +110,9 @@
         "wk:page":"\u010c\u00ed\u010dov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26b896f971f827a28e9e5f0f032777bb",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101787461,
-    "wof:lastmodified":1566645798,
+    "wof:lastmodified":1582382516,
     "wof:name":"\u010c\u00ed\u010dov",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/101/787/463/101787463.geojson
+++ b/data/101/787/463/101787463.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Zemianska Ol\u010da"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bc06fbc7672a398dde228e15cb3a9797",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101787463,
-    "wof:lastmodified":1566645796,
+    "wof:lastmodified":1582382516,
     "wof:name":"Zemianska Ol\u010da",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/101/787/465/101787465.geojson
+++ b/data/101/787/465/101787465.geojson
@@ -159,6 +159,9 @@
         "wk:page":"Kol\u00e1rovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63f8061e58b42eec200630b5d93db853",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":101787465,
-    "wof:lastmodified":1566645796,
+    "wof:lastmodified":1582382516,
     "wof:name":"Kol\u00e1rovo",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/101/787/467/101787467.geojson
+++ b/data/101/787/467/101787467.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Sv\u00e4t\u00fd Peter"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"54d227419995258a193a106bb0572666",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101787467,
-    "wof:lastmodified":1566645798,
+    "wof:lastmodified":1582382516,
     "wof:name":"Sv\u00e4t\u00fd Peter",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/101/787/485/101787485.geojson
+++ b/data/101/787/485/101787485.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Hurbanovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"94db04677b0ce550f5af7c5f80107cbc",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":101787485,
-    "wof:lastmodified":1566645795,
+    "wof:lastmodified":1582382516,
     "wof:name":"Hurbanovo",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/101/787/493/101787493.geojson
+++ b/data/101/787/493/101787493.geojson
@@ -110,6 +110,9 @@
         "wk:page":"B\u00fa\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2322c6c3c1afedbaa2b8c473f1a3ea22",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101787493,
-    "wof:lastmodified":1566645797,
+    "wof:lastmodified":1582382516,
     "wof:name":"B\u00fa\u010d",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/101/787/497/101787497.geojson
+++ b/data/101/787/497/101787497.geojson
@@ -129,6 +129,9 @@
         "wd:id":"Q389397"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d97a63ffe29fd8dd541d227ca75a6b4c",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101787497,
-    "wof:lastmodified":1566645796,
+    "wof:lastmodified":1582382516,
     "wof:name":"Gab\u010d\u00edkovo",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/787/501/101787501.geojson
+++ b/data/101/787/501/101787501.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Oko\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89f6fc3f801a9fec8d90ac350e37565e",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101787501,
-    "wof:lastmodified":1566645797,
+    "wof:lastmodified":1582382516,
     "wof:name":"Oko\u010d",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/787/505/101787505.geojson
+++ b/data/101/787/505/101787505.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Gbelce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c331da3d500bddee81bc05a181b77c47",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101787505,
-    "wof:lastmodified":1566645795,
+    "wof:lastmodified":1582382516,
     "wof:name":"Gbelce",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/832/689/101832689.geojson
+++ b/data/101/832/689/101832689.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Banka, Pie\u0161\u0165any District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc4ca2e0a24eb718e90e927701db9b41",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101832689,
-    "wof:lastmodified":1566645717,
+    "wof:lastmodified":1582382508,
     "wof:name":"Banka",
     "wof:parent_id":102080495,
     "wof:placetype":"locality",

--- a/data/101/832/709/101832709.geojson
+++ b/data/101/832/709/101832709.geojson
@@ -181,6 +181,9 @@
         "wk:page":"Trebi\u0161ov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b7516cfd91d177da0d94389ab006140",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645716,
+    "wof:lastmodified":1582382508,
     "wof:name":"Trebi\u0161ov",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/832/713/101832713.geojson
+++ b/data/101/832/713/101832713.geojson
@@ -110,6 +110,9 @@
         "wk:page":"\u010ca\u0148a"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5015d6a4232c0f1130c0c03c9d287986",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101832713,
-    "wof:lastmodified":1566645718,
+    "wof:lastmodified":1582382508,
     "wof:name":"\u010ca\u0148a",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/832/715/101832715.geojson
+++ b/data/101/832/715/101832715.geojson
@@ -206,6 +206,9 @@
         "wk:page":"Spi\u0161sk\u00e1 Nov\u00e1 Ves"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9147bd22fbbeedc3d96de68d8d1e8887",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645718,
+    "wof:lastmodified":1582382508,
     "wof:name":"Spi\u0161sk\u00e1 Nov\u00e1 Ves",
     "wof:parent_id":102080561,
     "wof:placetype":"locality",

--- a/data/101/832/717/101832717.geojson
+++ b/data/101/832/717/101832717.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Smi\u017eany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac0dde08f90bf7b89e0f305e9388e674",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101832717,
-    "wof:lastmodified":1566645720,
+    "wof:lastmodified":1582382509,
     "wof:name":"Smi\u017eany",
     "wof:parent_id":102080561,
     "wof:placetype":"locality",

--- a/data/101/832/719/101832719.geojson
+++ b/data/101/832/719/101832719.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Likavka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"102e6a00c68b5396558879683dde59d8",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101832719,
-    "wof:lastmodified":1566645720,
+    "wof:lastmodified":1582382508,
     "wof:name":"Likavka",
     "wof:parent_id":102080567,
     "wof:placetype":"locality",

--- a/data/101/832/721/101832721.geojson
+++ b/data/101/832/721/101832721.geojson
@@ -227,6 +227,9 @@
         "wk:page":"Ru\u017eomberok"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d38c3c3a9ed5c97a77b253cb236fa1ce",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645720,
+    "wof:lastmodified":1582382508,
     "wof:name":"Ru\u017eomberok",
     "wof:parent_id":102080567,
     "wof:placetype":"locality",

--- a/data/101/832/727/101832727.geojson
+++ b/data/101/832/727/101832727.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Gbe\u013eany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21969ef049d8a17645bd4e5c019136b3",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645721,
+    "wof:lastmodified":1582382509,
     "wof:name":"Gbe\u013eany",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/832/729/101832729.geojson
+++ b/data/101/832/729/101832729.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Rado\u013ea"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"501f6269acda09f22925ab6e011323dd",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101832729,
-    "wof:lastmodified":1566645721,
+    "wof:lastmodified":1582382509,
     "wof:name":"Rado\u013ea",
     "wof:parent_id":102080589,
     "wof:placetype":"locality",

--- a/data/101/832/733/101832733.geojson
+++ b/data/101/832/733/101832733.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Kendice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c257c96324eb3a6cb4a0482079bc0b69",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101832733,
-    "wof:lastmodified":1566645718,
+    "wof:lastmodified":1582382508,
     "wof:name":"Kendice",
     "wof:parent_id":102080591,
     "wof:placetype":"locality",

--- a/data/101/832/745/101832745.geojson
+++ b/data/101/832/745/101832745.geojson
@@ -178,6 +178,9 @@
         "wk:page":"Humenn\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f8abccea11735647e457be9471ff164",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645720,
+    "wof:lastmodified":1582382509,
     "wof:name":"Humenn\u00e9",
     "wof:parent_id":102080603,
     "wof:placetype":"locality",

--- a/data/101/832/747/101832747.geojson
+++ b/data/101/832/747/101832747.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Habovka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e866813014be4a30b1c30d8191af2b2d",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101832747,
-    "wof:lastmodified":1566645718,
+    "wof:lastmodified":1582382508,
     "wof:name":"Habovka",
     "wof:parent_id":102080605,
     "wof:placetype":"locality",

--- a/data/101/832/749/101832749.geojson
+++ b/data/101/832/749/101832749.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Zuberec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56d507a1d089904d2abbc98ed009d2e5",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":101832749,
-    "wof:lastmodified":1566645718,
+    "wof:lastmodified":1582382508,
     "wof:name":"Zuberec",
     "wof:parent_id":102080605,
     "wof:placetype":"locality",

--- a/data/101/832/753/101832753.geojson
+++ b/data/101/832/753/101832753.geojson
@@ -198,6 +198,9 @@
         "wk:page":"Ke\u017emarok"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9c5b3b2b7fbd1d9ec4f02ff5c7f8965a",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645716,
+    "wof:lastmodified":1582382508,
     "wof:name":"Ke\u017emarok",
     "wof:parent_id":102080609,
     "wof:placetype":"locality",

--- a/data/101/833/921/101833921.geojson
+++ b/data/101/833/921/101833921.geojson
@@ -184,6 +184,9 @@
         "wk:page":"Senec, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c496d6cd3e6f90aace0c4b39b65a088",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645727,
+    "wof:lastmodified":1582382509,
     "wof:name":"Senec",
     "wof:parent_id":102080465,
     "wof:placetype":"locality",

--- a/data/101/833/923/101833923.geojson
+++ b/data/101/833/923/101833923.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Vl\u010dany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2f6fe79aeb715fcfb8606308142420a8",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101833923,
-    "wof:lastmodified":1566645725,
+    "wof:lastmodified":1582382509,
     "wof:name":"Vl\u010dany",
     "wof:parent_id":102080467,
     "wof:placetype":"locality",

--- a/data/101/833/925/101833925.geojson
+++ b/data/101/833/925/101833925.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Neded"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f61b6f1e7734c8b02a3de7a2ac5a6aee",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101833925,
-    "wof:lastmodified":1566645726,
+    "wof:lastmodified":1582382509,
     "wof:name":"Neded",
     "wof:parent_id":102080467,
     "wof:placetype":"locality",

--- a/data/101/833/927/101833927.geojson
+++ b/data/101/833/927/101833927.geojson
@@ -116,6 +116,9 @@
         "wk:page":"\u010cierny Brod"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92d66133e3c39ee19ab58e40f16b8c93",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101833927,
-    "wof:lastmodified":1566645726,
+    "wof:lastmodified":1582382509,
     "wof:name":"\u010cierny Brod",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/833/933/101833933.geojson
+++ b/data/101/833/933/101833933.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Kri\u017eovany nad Dudv\u00e1hom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"880568504452641ea26388f8a89d6ac0",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645726,
+    "wof:lastmodified":1582382509,
     "wof:name":"Kri\u017eovany nad Dudv\u00e1hom",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/833/935/101833935.geojson
+++ b/data/101/833/935/101833935.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Moravany nad V\u00e1hom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c898d30416ab15c56cae819621c21ef7",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101833935,
-    "wof:lastmodified":1566645726,
+    "wof:lastmodified":1582382509,
     "wof:name":"Moravany nad V\u00e1hom",
     "wof:parent_id":102080495,
     "wof:placetype":"locality",

--- a/data/101/833/943/101833943.geojson
+++ b/data/101/833/943/101833943.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Sekule"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c39484a6c1cd775f8b70fc1c77fb15fa",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101833943,
-    "wof:lastmodified":1566645727,
+    "wof:lastmodified":1582382510,
     "wof:name":"Sekule",
     "wof:parent_id":102080505,
     "wof:placetype":"locality",

--- a/data/101/833/945/101833945.geojson
+++ b/data/101/833/945/101833945.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Moravsk\u00fd Sv\u00e4t\u00fd J\u00e1n"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a2f7be8c66fa405599afe0c2cbe5069d",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101833945,
-    "wof:lastmodified":1566645726,
+    "wof:lastmodified":1582382509,
     "wof:name":"Moravsk\u00fd Sv\u00e4t\u00fd J\u00e1n",
     "wof:parent_id":102080505,
     "wof:placetype":"locality",

--- a/data/101/834/115/101834115.geojson
+++ b/data/101/834/115/101834115.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Doln\u00fd Ohaj"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"103097fc8e0874bd049a535ed372a1eb",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101834115,
-    "wof:lastmodified":1566645729,
+    "wof:lastmodified":1582382510,
     "wof:name":"Doln\u00fd Ohaj",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/834/119/101834119.geojson
+++ b/data/101/834/119/101834119.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Mo\u010denok"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3e703799d40462c4011015f2dbfa6c39",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101834119,
-    "wof:lastmodified":1566645728,
+    "wof:lastmodified":1582382510,
     "wof:name":"Mo\u010denok",
     "wof:parent_id":102080467,
     "wof:placetype":"locality",

--- a/data/101/834/123/101834123.geojson
+++ b/data/101/834/123/101834123.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Doln\u00e1 Streda"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"97811cfdd387ffea2dc53e5bb7100e32",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101834123,
-    "wof:lastmodified":1566645730,
+    "wof:lastmodified":1582382510,
     "wof:name":"Doln\u00e1 Streda",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/834/125/101834125.geojson
+++ b/data/101/834/125/101834125.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Sere\u010f"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44f2eee58a844ada549cc0b615db0cf1",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":101834125,
-    "wof:lastmodified":1566645730,
+    "wof:lastmodified":1582382510,
     "wof:name":"Sere\u010f",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/834/131/101834131.geojson
+++ b/data/101/834/131/101834131.geojson
@@ -121,6 +121,9 @@
         "wk:page":"Mojm\u00edrovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9749165f4109a5e3890f2b8e5fd323e2",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645728,
+    "wof:lastmodified":1582382510,
     "wof:name":"Mojm\u00edrovce",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/834/157/101834157.geojson
+++ b/data/101/834/157/101834157.geojson
@@ -180,6 +180,9 @@
         "qs_pg:id":1042930
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1582e3c4e2271bcbbaa3264ef5ae84eb",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":101834157,
-    "wof:lastmodified":1566645727,
+    "wof:lastmodified":1582382510,
     "wof:name":"\u0160t\u00farovo",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/842/001/101842001.geojson
+++ b/data/101/842/001/101842001.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Skalit\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5070007eaf79f204a1103119ad1d11da",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101842001,
-    "wof:lastmodified":1566645693,
+    "wof:lastmodified":1582382506,
     "wof:name":"Skalit\u00e9",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/842/003/101842003.geojson
+++ b/data/101/842/003/101842003.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Svr\u010dinovec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"838c095a58a5c9f2cc953f379ed5d770",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101842003,
-    "wof:lastmodified":1566645693,
+    "wof:lastmodified":1582382506,
     "wof:name":"Svr\u010dinovec",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/842/005/101842005.geojson
+++ b/data/101/842/005/101842005.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Rakov\u00e1, \u010cadca District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"133b766f50de5ea3d2fbdafadb7244be",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101842005,
-    "wof:lastmodified":1566645694,
+    "wof:lastmodified":1582382506,
     "wof:name":"Rakov\u00e1",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/842/007/101842007.geojson
+++ b/data/101/842/007/101842007.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Sta\u0161kov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d542604b6f349d1d6a5c0b9ea7e863ce",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101842007,
-    "wof:lastmodified":1566645693,
+    "wof:lastmodified":1582382506,
     "wof:name":"Sta\u0161kov",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/842/009/101842009.geojson
+++ b/data/101/842/009/101842009.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Podvysok\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b2dea2d76135f323bcd525407b146b54",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101842009,
-    "wof:lastmodified":1566645693,
+    "wof:lastmodified":1582382506,
     "wof:name":"Podvysok\u00e1",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/842/013/101842013.geojson
+++ b/data/101/842/013/101842013.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Turzovka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"20763ab73b73e9cd99d7909cfd2b5bb7",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101842013,
-    "wof:lastmodified":1566645693,
+    "wof:lastmodified":1582382506,
     "wof:name":"Turzovka",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/842/017/101842017.geojson
+++ b/data/101/842/017/101842017.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Vysok\u00e1 nad Kysucou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"752a064b827b3b076353595f349be76b",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101842017,
-    "wof:lastmodified":1566645693,
+    "wof:lastmodified":1582382506,
     "wof:name":"Vysok\u00e1 nad Kysucou",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/842/019/101842019.geojson
+++ b/data/101/842/019/101842019.geojson
@@ -142,6 +142,9 @@
         "wk:page":"Kr\u00e1sno nad Kysucou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"346f04dbe5f5bb8e088eb7ae2ba2333d",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101842019,
-    "wof:lastmodified":1566645693,
+    "wof:lastmodified":1582382506,
     "wof:name":"Kr\u00e1sno nad Kysucou",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/843/717/101843717.geojson
+++ b/data/101/843/717/101843717.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Horn\u00e1 Pot\u00f4\u0148"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b76386230b5652b923e6750ff747d57",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101843717,
-    "wof:lastmodified":1566645713,
+    "wof:lastmodified":1582382508,
     "wof:name":"Horn\u00e1 Pot\u00f4\u0148",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/843/725/101843725.geojson
+++ b/data/101/843/725/101843725.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Semerovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f50f13c8fc835f1e25b9aac57c784f77",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101843725,
-    "wof:lastmodified":1566645702,
+    "wof:lastmodified":1582382507,
     "wof:name":"Semerovo",
     "wof:parent_id":102080463,
     "wof:placetype":"locality",

--- a/data/101/843/727/101843727.geojson
+++ b/data/101/843/727/101843727.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Bernol\u00e1kovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a08d19da56e01231b92abbc0a4fa2ff4",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101843727,
-    "wof:lastmodified":1566645715,
+    "wof:lastmodified":1582382508,
     "wof:name":"Bernol\u00e1kovo",
     "wof:parent_id":102080465,
     "wof:placetype":"locality",

--- a/data/101/843/729/101843729.geojson
+++ b/data/101/843/729/101843729.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Blatn\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35f6967f295baec625d2ac51152856fd",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101843729,
-    "wof:lastmodified":1566645715,
+    "wof:lastmodified":1582382508,
     "wof:name":"Blatn\u00e9",
     "wof:parent_id":102080465,
     "wof:placetype":"locality",

--- a/data/101/843/731/101843731.geojson
+++ b/data/101/843/731/101843731.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Kajal (village)"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1585e1f05bd6db029fa15b8a611b3ee",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101843731,
-    "wof:lastmodified":1566645699,
+    "wof:lastmodified":1582382507,
     "wof:name":"Kajal",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/843/733/101843733.geojson
+++ b/data/101/843/733/101843733.geojson
@@ -144,6 +144,9 @@
         "wk:page":"Sl\u00e1dkovi\u010dovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2c16bf0148d108515235284539001c5",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101843733,
-    "wof:lastmodified":1566645706,
+    "wof:lastmodified":1582382507,
     "wof:name":"Sl\u00e1dkovi\u010dovo",
     "wof:parent_id":102080469,
     "wof:placetype":"locality",

--- a/data/101/843/743/101843743.geojson
+++ b/data/101/843/743/101843743.geojson
@@ -114,6 +114,9 @@
         "wk:page":"\u010cakajovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"17adeb2ac5987d612f80139e51d7ca2c",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645712,
+    "wof:lastmodified":1582382508,
     "wof:name":"\u010cakajovce",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/843/751/101843751.geojson
+++ b/data/101/843/751/101843751.geojson
@@ -184,6 +184,9 @@
         "wk:page":"Levice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"484bef7673a84102eb6869cbf4bdcb09",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645707,
+    "wof:lastmodified":1582382508,
     "wof:name":"Levice",
     "wof:parent_id":102080477,
     "wof:placetype":"locality",

--- a/data/101/843/761/101843761.geojson
+++ b/data/101/843/761/101843761.geojson
@@ -116,6 +116,9 @@
         "wk:page":"\u010cerven\u00edk"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d48fa82c706e9bc8dd265376062a206f",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101843761,
-    "wof:lastmodified":1566645708,
+    "wof:lastmodified":1582382508,
     "wof:name":"\u010cerven\u00edk",
     "wof:parent_id":102080481,
     "wof:placetype":"locality",

--- a/data/101/843/763/101843763.geojson
+++ b/data/101/843/763/101843763.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Bojni\u010dky"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"48f0f2c34c15e6c453f5e4bef78658b1",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101843763,
-    "wof:lastmodified":1566645697,
+    "wof:lastmodified":1582382507,
     "wof:name":"Bojni\u010dky",
     "wof:parent_id":102080481,
     "wof:placetype":"locality",

--- a/data/101/843/765/101843765.geojson
+++ b/data/101/843/765/101843765.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Dudince"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e6483868d7ae2a7c82071014dbc6fee",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":101843765,
-    "wof:lastmodified":1566645698,
+    "wof:lastmodified":1582382507,
     "wof:name":"Dudince",
     "wof:parent_id":102080483,
     "wof:placetype":"locality",

--- a/data/101/843/779/101843779.geojson
+++ b/data/101/843/779/101843779.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Zelene\u010d, Slovakia"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca243937d55013bf9895511e1a487425",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645705,
+    "wof:lastmodified":1582382507,
     "wof:name":"Zelene\u010d",
     "wof:parent_id":102080489,
     "wof:placetype":"locality",

--- a/data/101/843/789/101843789.geojson
+++ b/data/101/843/789/101843789.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Chynorany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4de9ca6388d086996019803f66f69aea",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101843789,
-    "wof:lastmodified":1566645714,
+    "wof:lastmodified":1582382508,
     "wof:name":"Chynorany",
     "wof:parent_id":102080503,
     "wof:placetype":"locality",

--- a/data/101/843/791/101843791.geojson
+++ b/data/101/843/791/101843791.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Doj\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3c43105d4bfbdd0009bf5fd9bf5de246",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101843791,
-    "wof:lastmodified":1566645698,
+    "wof:lastmodified":1582382507,
     "wof:name":"Doj\u010d",
     "wof:parent_id":102080505,
     "wof:placetype":"locality",

--- a/data/101/843/797/101843797.geojson
+++ b/data/101/843/797/101843797.geojson
@@ -160,6 +160,9 @@
         "wk:page":"Detva"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"975b5fc19baf36d0976f756ee77a9dd4",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645696,
+    "wof:lastmodified":1582382507,
     "wof:name":"Detva",
     "wof:parent_id":102080507,
     "wof:placetype":"locality",

--- a/data/101/843/807/101843807.geojson
+++ b/data/101/843/807/101843807.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Hlin\u00edk nad Hronom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43a5050e9d12d99d1df9bdb1f179191a",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645710,
+    "wof:lastmodified":1582382508,
     "wof:name":"Hlin\u00edk nad Hronom",
     "wof:parent_id":102080519,
     "wof:placetype":"locality",

--- a/data/101/843/815/101843815.geojson
+++ b/data/101/843/815/101843815.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Bo\u0161\u00e1ca"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"59eb7b6d0d7ac0caa1e973239926d19a",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101843815,
-    "wof:lastmodified":1566645709,
+    "wof:lastmodified":1582382508,
     "wof:name":"Bo\u0161\u00e1ca",
     "wof:parent_id":102080521,
     "wof:placetype":"locality",

--- a/data/101/843/823/101843823.geojson
+++ b/data/101/843/823/101843823.geojson
@@ -123,6 +123,9 @@
         "wk:page":"Medzibrod"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"324a2d3635b4bd37761038c70cebd2a5",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645709,
+    "wof:lastmodified":1582382508,
     "wof:name":"Medzibrod",
     "wof:parent_id":102080531,
     "wof:placetype":"locality",

--- a/data/101/843/827/101843827.geojson
+++ b/data/101/843/827/101843827.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Pravenec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"07136594de345e1ea9644f2555eefd93",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101843827,
-    "wof:lastmodified":1566645699,
+    "wof:lastmodified":1582382507,
     "wof:name":"Pravenec",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/843/833/101843833.geojson
+++ b/data/101/843/833/101843833.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Sebedra\u017eie"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14bcc9ef458569a0605f8353587c417f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101843833,
-    "wof:lastmodified":1566645702,
+    "wof:lastmodified":1582382507,
     "wof:name":"Sebedra\u017eie",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/843/835/101843835.geojson
+++ b/data/101/843/835/101843835.geojson
@@ -369,6 +369,9 @@
         "wk:page":"Mo\u0161ovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b40fa6cbad993f3eef11bd9b596d09c",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
         }
     ],
     "wof:id":101843835,
-    "wof:lastmodified":1566645701,
+    "wof:lastmodified":1582382507,
     "wof:name":"Mo\u0161ovce",
     "wof:parent_id":102080539,
     "wof:placetype":"locality",

--- a/data/101/843/849/101843849.geojson
+++ b/data/101/843/849/101843849.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Tren\u010dianska Turn\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a4d5e4fef3e542f64ce1fe71cc377907",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101843849,
-    "wof:lastmodified":1566645709,
+    "wof:lastmodified":1582382508,
     "wof:name":"Tren\u010dianska Turn\u00e1",
     "wof:parent_id":102080541,
     "wof:placetype":"locality",

--- a/data/101/843/851/101843851.geojson
+++ b/data/101/843/851/101843851.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Pohorel\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"483394bd97ee19a37ed0020eedf0444b",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101843851,
-    "wof:lastmodified":1566645701,
+    "wof:lastmodified":1582382507,
     "wof:name":"Pohorel\u00e1",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/843/853/101843853.geojson
+++ b/data/101/843/853/101843853.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Nemeck\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1950d3f769fe02e1f01a91e1244160b7",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101843853,
-    "wof:lastmodified":1566645710,
+    "wof:lastmodified":1582382508,
     "wof:name":"Nemeck\u00e1",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/843/861/101843861.geojson
+++ b/data/101/843/861/101843861.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Ni\u017en\u00fd \u017dipov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55e395eb48c68d9b5bf863b66ed44387",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101843861,
-    "wof:lastmodified":1566645701,
+    "wof:lastmodified":1582382507,
     "wof:name":"Ni\u017en\u00fd \u017dipov",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/843/863/101843863.geojson
+++ b/data/101/843/863/101843863.geojson
@@ -157,6 +157,9 @@
         "qs_pg:id":402161
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa6e4e3cf2cdbc3d5755a33f2720fc73",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":101843863,
-    "wof:lastmodified":1566645711,
+    "wof:lastmodified":1582382508,
     "wof:name":"Kr\u00e1\u013eovsk\u00fd Chlmec",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/843/869/101843869.geojson
+++ b/data/101/843/869/101843869.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Streda nad Bodrogom"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52143a7ef7703ab7ced0076301fe8c7f",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101843869,
-    "wof:lastmodified":1566645701,
+    "wof:lastmodified":1582382507,
     "wof:name":"Streda nad Bodrogom",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/843/871/101843871.geojson
+++ b/data/101/843/871/101843871.geojson
@@ -162,6 +162,9 @@
         "wk:page":"Dob\u0161in\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0dcfc7bcb8196873c43f6efd0e573d7",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101843871,
-    "wof:lastmodified":1566645710,
+    "wof:lastmodified":1582382508,
     "wof:name":"Dob\u0161in\u00e1",
     "wof:parent_id":102080553,
     "wof:placetype":"locality",

--- a/data/101/843/877/101843877.geojson
+++ b/data/101/843/877/101843877.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Kysak"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56e01671ecc8d45d2152fda7849610b0",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101843877,
-    "wof:lastmodified":1566645709,
+    "wof:lastmodified":1582382508,
     "wof:name":"Kysak",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/843/885/101843885.geojson
+++ b/data/101/843/885/101843885.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Haniska, Ko\u0161ice-okolie District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6c02dec00aa3b1e35236edb7e4423ac",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101843885,
-    "wof:lastmodified":1566645710,
+    "wof:lastmodified":1582382508,
     "wof:name":"Haniska",
     "wof:parent_id":102080557,
     "wof:placetype":"locality",

--- a/data/101/843/889/101843889.geojson
+++ b/data/101/843/889/101843889.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Helcmanovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5475738d580c1fc1cd881df3d752563c",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101843889,
-    "wof:lastmodified":1566645699,
+    "wof:lastmodified":1582382507,
     "wof:name":"Helcmanovce",
     "wof:parent_id":102080559,
     "wof:placetype":"locality",

--- a/data/101/843/893/101843893.geojson
+++ b/data/101/843/893/101843893.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Spi\u0161sk\u00fd Hru\u0161ov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd4b763ddf84a32c520b047d7a9b4827",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101843893,
-    "wof:lastmodified":1566645702,
+    "wof:lastmodified":1582382507,
     "wof:name":"Spi\u0161sk\u00fd Hru\u0161ov",
     "wof:parent_id":102080561,
     "wof:placetype":"locality",

--- a/data/101/843/895/101843895.geojson
+++ b/data/101/843/895/101843895.geojson
@@ -124,6 +124,9 @@
         "wk:page":"Vinn\u00e9"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23f28744b6772bdfb5b4b1e4fac055f7",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":101843895,
-    "wof:lastmodified":1566645700,
+    "wof:lastmodified":1582382507,
     "wof:name":"Vinn\u00e9",
     "wof:parent_id":102080563,
     "wof:placetype":"locality",

--- a/data/101/843/909/101843909.geojson
+++ b/data/101/843/909/101843909.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Doln\u00e1 Marikov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"06dc0320774620a7d518bee96b5a1169",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101843909,
-    "wof:lastmodified":1566645697,
+    "wof:lastmodified":1582382507,
     "wof:name":"Doln\u00e1 Marikov\u00e1",
     "wof:parent_id":102080575,
     "wof:placetype":"locality",

--- a/data/101/843/913/101843913.geojson
+++ b/data/101/843/913/101843913.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Liptovsk\u00e1 Kokava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"094251bcf40ba1d09b0db08d8dee1f4e",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101843913,
-    "wof:lastmodified":1566645705,
+    "wof:lastmodified":1582382507,
     "wof:name":"Liptovsk\u00e1 Kokava",
     "wof:parent_id":102080577,
     "wof:placetype":"locality",

--- a/data/101/843/923/101843923.geojson
+++ b/data/101/843/923/101843923.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Predmier"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"68cdcb4b8b8bb0871fcbc9ca1fdd2125",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101843923,
-    "wof:lastmodified":1566645703,
+    "wof:lastmodified":1582382507,
     "wof:name":"Predmier",
     "wof:parent_id":102080581,
     "wof:placetype":"locality",

--- a/data/101/843/935/101843935.geojson
+++ b/data/101/843/935/101843935.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Terchov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a31c25c5c1a84cf4d7150ba25a5e1b0e",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101843935,
-    "wof:lastmodified":1561841691,
+    "wof:lastmodified":1582382507,
     "wof:name":"Terchov\u00e1",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/843/941/101843941.geojson
+++ b/data/101/843/941/101843941.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Chlebnice"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff8bf4ba09172667ffbe7dc2344f1a41",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101843941,
-    "wof:lastmodified":1566645703,
+    "wof:lastmodified":1582382507,
     "wof:name":"Chlebnice",
     "wof:parent_id":102080587,
     "wof:placetype":"locality",

--- a/data/101/843/945/101843945.geojson
+++ b/data/101/843/945/101843945.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Neslu\u0161a"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2da4665619620b1d1706db1671e1e6f4",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101843945,
-    "wof:lastmodified":1566645713,
+    "wof:lastmodified":1582382508,
     "wof:name":"Neslu\u0161a",
     "wof:parent_id":102080589,
     "wof:placetype":"locality",

--- a/data/101/843/953/101843953.geojson
+++ b/data/101/843/953/101843953.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Leme\u0161any"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"47d187b4fa83fa93dd52d89eac353c40",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645697,
+    "wof:lastmodified":1582382507,
     "wof:name":"Leme\u0161any",
     "wof:parent_id":102080591,
     "wof:placetype":"locality",

--- a/data/101/843/969/101843969.geojson
+++ b/data/101/843/969/101843969.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Makov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"83601e7892f874b515c5646a382df2b6",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101843969,
-    "wof:lastmodified":1566645708,
+    "wof:lastmodified":1582382508,
     "wof:name":"Makov",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/843/977/101843977.geojson
+++ b/data/101/843/977/101843977.geojson
@@ -116,6 +116,9 @@
         "wk:page":"\u010cir\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39e469202bf57aa98a52f1df7f45fd86",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101843977,
-    "wof:lastmodified":1566645702,
+    "wof:lastmodified":1582382507,
     "wof:name":"\u010cir\u010d",
     "wof:parent_id":102080611,
     "wof:placetype":"locality",

--- a/data/101/843/979/101843979.geojson
+++ b/data/101/843/979/101843979.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Plave\u010d, Star\u00e1 \u013dubov\u0148a District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a8f0b46fec6ed2a3a7cb4fa682f50990",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101843979,
-    "wof:lastmodified":1566645703,
+    "wof:lastmodified":1582382507,
     "wof:name":"Plave\u010d",
     "wof:parent_id":102080611,
     "wof:placetype":"locality",

--- a/data/101/843/981/101843981.geojson
+++ b/data/101/843/981/101843981.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Vy\u0161n\u00e9 Ru\u017ebachy"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef986ffe9a7dbc983012df82e6cb7ec6",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645715,
+    "wof:lastmodified":1582382508,
     "wof:name":"Vy\u0161n\u00e9 Ru\u017ebachy",
     "wof:parent_id":102080611,
     "wof:placetype":"locality",

--- a/data/101/843/983/101843983.geojson
+++ b/data/101/843/983/101843983.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Hniezdne"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e7995bfad549cf5b6485f23081717a53",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101843983,
-    "wof:lastmodified":1566645702,
+    "wof:lastmodified":1582382507,
     "wof:name":"Hniezdne",
     "wof:parent_id":102080611,
     "wof:placetype":"locality",

--- a/data/101/845/243/101845243.geojson
+++ b/data/101/845/243/101845243.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Holice, Dunajsk\u00e1 Streda District"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38ef7821abe7f86ebc8b9223d49eaa33",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101845243,
-    "wof:lastmodified":1566645692,
+    "wof:lastmodified":1582382506,
     "wof:name":"Holice",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/845/709/101845709.geojson
+++ b/data/101/845/709/101845709.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Rohovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"abc74db4a7eff85a1d562d2de6cc83c5",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101845709,
-    "wof:lastmodified":1566645692,
+    "wof:lastmodified":1582382506,
     "wof:name":"Rohovce",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/847/801/101847801.geojson
+++ b/data/101/847/801/101847801.geojson
@@ -110,6 +110,9 @@
         "wk:page":"O\u0161\u010dadnica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26bd538202c6870e82920e2eb55a5e99",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101847801,
-    "wof:lastmodified":1566645775,
+    "wof:lastmodified":1582382514,
     "wof:name":"O\u0161\u010dadnica",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/847/803/101847803.geojson
+++ b/data/101/847/803/101847803.geojson
@@ -150,6 +150,9 @@
         "wd:id":"Q592301"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ad1ae0e3f0e9fd22da34a2ada3cd0a3",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101847803,
-    "wof:lastmodified":1566645775,
+    "wof:lastmodified":1582382514,
     "wof:name":"Spi\u0161sk\u00e1 Star\u00e1 Ves",
     "wof:parent_id":102080609,
     "wof:placetype":"locality",

--- a/data/101/847/805/101847805.geojson
+++ b/data/101/847/805/101847805.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Oravsk\u00e1 Polhora"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25e3986d1c396cdf7b8c21acf51aba98",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101847805,
-    "wof:lastmodified":1566645775,
+    "wof:lastmodified":1582382514,
     "wof:name":"Oravsk\u00e1 Polhora",
     "wof:parent_id":102080615,
     "wof:placetype":"locality",

--- a/data/101/847/821/101847821.geojson
+++ b/data/101/847/821/101847821.geojson
@@ -148,6 +148,9 @@
         "wk:page":"N\u00e1mestovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1221f1f75dddb324ba61ec382da2fba6",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645774,
+    "wof:lastmodified":1582382514,
     "wof:name":"N\u00e1mestovo",
     "wof:parent_id":102080615,
     "wof:placetype":"locality",

--- a/data/101/847/823/101847823.geojson
+++ b/data/101/847/823/101847823.geojson
@@ -112,6 +112,9 @@
         "qs_pg:id":908986
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9fa005511fe0e1f7822f01f7007a4e6f",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101847823,
-    "wof:lastmodified":1566645775,
+    "wof:lastmodified":1582382514,
     "wof:name":"Oravsk\u00e1 Jasenica",
     "wof:parent_id":102080615,
     "wof:placetype":"locality",

--- a/data/101/857/935/101857935.geojson
+++ b/data/101/857/935/101857935.geojson
@@ -128,6 +128,9 @@
         "wd:id":"Q972948"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"890001f28eaf693250976fd55ab4b4b2",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101857935,
-    "wof:lastmodified":1566645715,
+    "wof:lastmodified":1582382508,
     "wof:name":"Hradi\u0161te",
     "wof:parent_id":102080503,
     "wof:placetype":"locality",

--- a/data/101/858/939/101858939.geojson
+++ b/data/101/858/939/101858939.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q988208"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"780838010db6a26415a919f09810ed9f",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101858939,
-    "wof:lastmodified":1566645723,
+    "wof:lastmodified":1582382509,
     "wof:name":"Kostoln\u00e9 Kra\u010dany",
     "wof:parent_id":102080453,
     "wof:placetype":"locality",

--- a/data/101/858/941/101858941.geojson
+++ b/data/101/858/941/101858941.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Alek\u0161ince"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1e52ae85263c4950a7b65142bb489e9d",
     "wof:hierarchy":[
         {
@@ -132,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645724,
+    "wof:lastmodified":1582382509,
     "wof:name":"Alek\u0161ince",
     "wof:parent_id":102080473,
     "wof:placetype":"locality",

--- a/data/101/858/943/101858943.geojson
+++ b/data/101/858/943/101858943.geojson
@@ -172,6 +172,9 @@
         "wk:page":"Fi\u013eakovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"454a77a6f016c6e8a4dc8141218b8264",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":101858943,
-    "wof:lastmodified":1566645724,
+    "wof:lastmodified":1582382509,
     "wof:name":"Fi\u013eakovo",
     "wof:parent_id":102080497,
     "wof:placetype":"locality",

--- a/data/101/858/945/101858945.geojson
+++ b/data/101/858/945/101858945.geojson
@@ -109,6 +109,9 @@
         "wd:id":"Q1037257"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d334babf9310875c662166f028b9c66",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101858945,
-    "wof:lastmodified":1566645724,
+    "wof:lastmodified":1582382509,
     "wof:name":"Hodru\u0161a - H\u00e1mre",
     "wof:parent_id":102080499,
     "wof:placetype":"locality",

--- a/data/101/858/947/101858947.geojson
+++ b/data/101/858/947/101858947.geojson
@@ -114,6 +114,10 @@
         "wd:id":"Q1073020"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d6dd6fa83c5718aea1e088064c5019f4",
     "wof:hierarchy":[
         {
@@ -125,7 +129,7 @@
         }
     ],
     "wof:id":101858947,
-    "wof:lastmodified":1566645724,
+    "wof:lastmodified":1582382509,
     "wof:name":"Utek\u00e1\u010d",
     "wof:parent_id":102080513,
     "wof:placetype":"locality",

--- a/data/101/858/951/101858951.geojson
+++ b/data/101/858/951/101858951.geojson
@@ -121,6 +121,10 @@
         "wk:page":"Vyhne"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dbbb71e08d0b3a267a1e2fdfe20c1d29",
     "wof:hierarchy":[
         {
@@ -132,7 +136,7 @@
         }
     ],
     "wof:id":101858951,
-    "wof:lastmodified":1566645724,
+    "wof:lastmodified":1582382509,
     "wof:name":"Vyhne",
     "wof:parent_id":102080519,
     "wof:placetype":"locality",

--- a/data/101/858/953/101858953.geojson
+++ b/data/101/858/953/101858953.geojson
@@ -115,6 +115,10 @@
         "wk:page":"Hronec"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"67e46de0ba0393d7b86797bf852a94d0",
     "wof:hierarchy":[
         {
@@ -126,7 +130,7 @@
         }
     ],
     "wof:id":101858953,
-    "wof:lastmodified":1566645723,
+    "wof:lastmodified":1582382509,
     "wof:name":"Hronec",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/858/955/101858955.geojson
+++ b/data/101/858/955/101858955.geojson
@@ -153,6 +153,10 @@
         "wk:page":"\u017dehra"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82a1cac85ba00b647d41232ec5625191",
     "wof:hierarchy":[
         {
@@ -164,7 +168,7 @@
         }
     ],
     "wof:id":101858955,
-    "wof:lastmodified":1566645724,
+    "wof:lastmodified":1582382509,
     "wof:name":"\u017dehra",
     "wof:parent_id":102080561,
     "wof:placetype":"locality",

--- a/data/101/858/957/101858957.geojson
+++ b/data/101/858/957/101858957.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Partiz\u00e1nska \u013dup\u010da"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab856a8917eaffcc5b8505b0359d9c1e",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101858957,
-    "wof:lastmodified":1566645724,
+    "wof:lastmodified":1582382509,
     "wof:name":"Partiz\u00e1nska \u013dup\u010da",
     "wof:parent_id":102080577,
     "wof:placetype":"locality",

--- a/data/101/860/151/101860151.geojson
+++ b/data/101/860/151/101860151.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Valaliky"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"89bbc3bfd2494ae4fc8fa717111b4f56",
     "wof:hierarchy":[
         {
@@ -129,7 +133,7 @@
         }
     ],
     "wof:id":101860151,
-    "wof:lastmodified":1566645722,
+    "wof:lastmodified":1582382509,
     "wof:name":"Valaliky",
     "wof:parent_id":102080535,
     "wof:placetype":"locality",

--- a/data/101/860/153/101860153.geojson
+++ b/data/101/860/153/101860153.geojson
@@ -115,6 +115,9 @@
         "wk:page":"\u010cierna"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3114a4af9fce6c1b068aa304e0e69aaa",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101860153,
-    "wof:lastmodified":1566645722,
+    "wof:lastmodified":1582382509,
     "wof:name":"\u010cierna nad Tisou",
     "wof:parent_id":102080551,
     "wof:placetype":"locality",

--- a/data/101/860/157/101860157.geojson
+++ b/data/101/860/157/101860157.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Krpe\u013eany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d70b255bb5cea12fab31dc212830621",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101860157,
-    "wof:lastmodified":1566645721,
+    "wof:lastmodified":1582382509,
     "wof:name":"Krpe\u013eany",
     "wof:parent_id":102080569,
     "wof:placetype":"locality",

--- a/data/101/860/159/101860159.geojson
+++ b/data/101/860/159/101860159.geojson
@@ -106,6 +106,9 @@
         "wd:id":"Q1045107"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54c2ab392ce46326be45aec5a4bfe7e7",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101860159,
-    "wof:lastmodified":1566645721,
+    "wof:lastmodified":1582382509,
     "wof:name":"Lietavsk\u00e1 Svinn\u00e1 - Babkov",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/860/161/101860161.geojson
+++ b/data/101/860/161/101860161.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Divina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7d81f4350f7b7fc62558baadbbd7be4",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645722,
+    "wof:lastmodified":1582382509,
     "wof:name":"Divina",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/860/163/101860163.geojson
+++ b/data/101/860/163/101860163.geojson
@@ -113,6 +113,10 @@
         "wk:page":"Var\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6179c1c2e325fefe9ffb775005192456",
     "wof:hierarchy":[
         {
@@ -127,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645723,
+    "wof:lastmodified":1582382509,
     "wof:name":"Var\u00edn",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/860/165/101860165.geojson
+++ b/data/101/860/165/101860165.geojson
@@ -116,6 +116,10 @@
         "wk:page":"Stre\u010dno"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a0ff2aae120f572ccccf63df29a59e0",
     "wof:hierarchy":[
         {
@@ -130,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645723,
+    "wof:lastmodified":1582382509,
     "wof:name":"Stre\u010dno",
     "wof:parent_id":102080585,
     "wof:placetype":"locality",

--- a/data/101/860/167/101860167.geojson
+++ b/data/101/860/167/101860167.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Povina"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"638356940966c4e24d8f447841142963",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101860167,
-    "wof:lastmodified":1566645722,
+    "wof:lastmodified":1582382509,
     "wof:name":"Povina",
     "wof:parent_id":102080589,
     "wof:placetype":"locality",

--- a/data/101/860/169/101860169.geojson
+++ b/data/101/860/169/101860169.geojson
@@ -115,6 +115,10 @@
         "wk:page":"Horn\u00fd Vadi\u010dov"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44e2d0f1c72f0f35163d4068ae686bdb",
     "wof:hierarchy":[
         {
@@ -126,7 +130,7 @@
         }
     ],
     "wof:id":101860169,
-    "wof:lastmodified":1566645722,
+    "wof:lastmodified":1582382509,
     "wof:name":"Horn\u00fd Vadi\u010dov",
     "wof:parent_id":102080589,
     "wof:placetype":"locality",

--- a/data/101/860/171/101860171.geojson
+++ b/data/101/860/171/101860171.geojson
@@ -196,6 +196,10 @@
         "wk:page":"Vysok\u00e9 Tatry"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4edba1c9e3003b0155442b8440828d6",
     "wof:hierarchy":[
         {
@@ -210,7 +214,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645723,
+    "wof:lastmodified":1582382509,
     "wof:name":"Vysok\u00e9 Tatry",
     "wof:parent_id":102080597,
     "wof:placetype":"locality",

--- a/data/101/860/175/101860175.geojson
+++ b/data/101/860/175/101860175.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Z\u00e1kop\u010die"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e257978f153555110233164446901d8",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101860175,
-    "wof:lastmodified":1566645722,
+    "wof:lastmodified":1582382509,
     "wof:name":"Z\u00e1kop\u010die",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/860/177/101860177.geojson
+++ b/data/101/860/177/101860177.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Lomni\u010dka (Star\u00e1 \u013dubov\u0148a District)"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3bb8f192d8a8b07b1cd3cc19745409d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101860177,
-    "wof:lastmodified":1566645723,
+    "wof:lastmodified":1582382509,
     "wof:name":"Lomni\u010dka",
     "wof:parent_id":102080611,
     "wof:placetype":"locality",

--- a/data/101/860/179/101860179.geojson
+++ b/data/101/860/179/101860179.geojson
@@ -122,6 +122,10 @@
         "qs_pg:id":851374
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"726a0405da61c9ffd6921a3f05281ebb",
     "wof:hierarchy":[
         {
@@ -133,7 +137,7 @@
         }
     ],
     "wof:id":101860179,
-    "wof:lastmodified":1566645723,
+    "wof:lastmodified":1582382509,
     "wof:name":"Oravsk\u00e1 Lesn\u00e1",
     "wof:parent_id":102080615,
     "wof:placetype":"locality",

--- a/data/101/860/181/101860181.geojson
+++ b/data/101/860/181/101860181.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Lokca"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"abe0cf1ca0be8d1f5badab63e83ecdb7",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101860181,
-    "wof:lastmodified":1566645722,
+    "wof:lastmodified":1582382509,
     "wof:name":"Lokca",
     "wof:parent_id":102080615,
     "wof:placetype":"locality",

--- a/data/101/861/297/101861297.geojson
+++ b/data/101/861/297/101861297.geojson
@@ -154,6 +154,10 @@
         "wk:page":"Ve\u013ek\u00fd \u0160ari\u0161"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"383dcd8cd523da8f1014772689dc46a8",
     "wof:hierarchy":[
         {
@@ -168,7 +172,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645715,
+    "wof:lastmodified":1582382508,
     "wof:name":"Ve\u013ek\u00fd \u0160ari\u0161",
     "wof:parent_id":102080591,
     "wof:placetype":"locality",

--- a/data/101/875/819/101875819.geojson
+++ b/data/101/875/819/101875819.geojson
@@ -183,6 +183,10 @@
         "wk:page":"Zlat\u00e9 Moravce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a32c62e8b1f1b5c95c8846152e3901c4",
     "wof:hierarchy":[
         {
@@ -197,7 +201,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645695,
+    "wof:lastmodified":1582382506,
     "wof:name":"Zlat\u00e9 Moravce",
     "wof:parent_id":102080485,
     "wof:placetype":"locality",

--- a/data/101/875/821/101875821.geojson
+++ b/data/101/875/821/101875821.geojson
@@ -152,6 +152,10 @@
         "wk:page":"Nov\u00e1 Ba\u0148a"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c47218f63b0de5bfbd3784f143870c1",
     "wof:hierarchy":[
         {
@@ -163,7 +167,7 @@
         }
     ],
     "wof:id":101875821,
-    "wof:lastmodified":1566645695,
+    "wof:lastmodified":1582382506,
     "wof:name":"Nov\u00e1 Ba\u0148a",
     "wof:parent_id":102080499,
     "wof:placetype":"locality",

--- a/data/101/875/823/101875823.geojson
+++ b/data/101/875/823/101875823.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Tovarn\u00edky"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7356ceb88a4b14e76dadcc2f8d4dccb",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101875823,
-    "wof:lastmodified":1566645696,
+    "wof:lastmodified":1582382507,
     "wof:name":"Tovarn\u00edky",
     "wof:parent_id":102080501,
     "wof:placetype":"locality",

--- a/data/101/875/825/101875825.geojson
+++ b/data/101/875/825/101875825.geojson
@@ -152,6 +152,10 @@
         "wk:page":"Nov\u00e1ky"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"50f43057cf5034caa5a3c0db2ae66eaf",
     "wof:hierarchy":[
         {
@@ -163,7 +167,7 @@
         }
     ],
     "wof:id":101875825,
-    "wof:lastmodified":1566645696,
+    "wof:lastmodified":1582382507,
     "wof:name":"Nov\u00e1ky",
     "wof:parent_id":102080537,
     "wof:placetype":"locality",

--- a/data/101/875/827/101875827.geojson
+++ b/data/101/875/827/101875827.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Valask\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9ead95c3533a4243ccc42b8414f8ae4",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101875827,
-    "wof:lastmodified":1566645694,
+    "wof:lastmodified":1582382506,
     "wof:name":"Valask\u00e1",
     "wof:parent_id":102080545,
     "wof:placetype":"locality",

--- a/data/101/875/829/101875829.geojson
+++ b/data/101/875/829/101875829.geojson
@@ -115,6 +115,10 @@
         "wk:page":"Kluknava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eebba8497d4447155c545f00985ee893",
     "wof:hierarchy":[
         {
@@ -126,7 +130,7 @@
         }
     ],
     "wof:id":101875829,
-    "wof:lastmodified":1566645695,
+    "wof:lastmodified":1582382506,
     "wof:name":"Kluknava",
     "wof:parent_id":102080559,
     "wof:placetype":"locality",

--- a/data/101/875/831/101875831.geojson
+++ b/data/101/875/831/101875831.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Liskov\u00e1"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85fba9750000a769e190414e19de7614",
     "wof:hierarchy":[
         {
@@ -129,7 +133,7 @@
         }
     ],
     "wof:id":101875831,
-    "wof:lastmodified":1566645696,
+    "wof:lastmodified":1582382507,
     "wof:name":"Liskov\u00e1",
     "wof:parent_id":102080567,
     "wof:placetype":"locality",

--- a/data/101/875/835/101875835.geojson
+++ b/data/101/875/835/101875835.geojson
@@ -112,6 +112,10 @@
         "wk:page":"Brvni\u0161te"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ea259dbd0aec2ba5ec847183e8468ad",
     "wof:hierarchy":[
         {
@@ -123,7 +127,7 @@
         }
     ],
     "wof:id":101875835,
-    "wof:lastmodified":1566645695,
+    "wof:lastmodified":1582382506,
     "wof:name":"Brvni\u0161te",
     "wof:parent_id":102080575,
     "wof:placetype":"locality",

--- a/data/101/875/837/101875837.geojson
+++ b/data/101/875/837/101875837.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Ochodnica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0549b3ca5f40197f5ee768b6ddbfcc87",
     "wof:hierarchy":[
         {
@@ -129,7 +133,7 @@
         }
     ],
     "wof:id":101875837,
-    "wof:lastmodified":1566645696,
+    "wof:lastmodified":1582382507,
     "wof:name":"Ochodnica",
     "wof:parent_id":102080589,
     "wof:placetype":"locality",

--- a/data/101/875/839/101875839.geojson
+++ b/data/101/875/839/101875839.geojson
@@ -197,6 +197,10 @@
         "wk:page":"Vranov nad Top\u013eou"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"77cdb0847fc94d66e7f4eba498ba7497",
     "wof:hierarchy":[
         {
@@ -211,7 +215,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645696,
+    "wof:lastmodified":1582382507,
     "wof:name":"Vranov nad Top\u013eou",
     "wof:parent_id":102080593,
     "wof:placetype":"locality",

--- a/data/101/875/841/101875841.geojson
+++ b/data/101/875/841/101875841.geojson
@@ -115,6 +115,10 @@
         "wk:page":"\u010cierne"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ca07d318f99a415eeab9f809dd63bdb",
     "wof:hierarchy":[
         {
@@ -126,7 +130,7 @@
         }
     ],
     "wof:id":101875841,
-    "wof:lastmodified":1566645695,
+    "wof:lastmodified":1582382506,
     "wof:name":"\u010cierne",
     "wof:parent_id":102080607,
     "wof:placetype":"locality",

--- a/data/101/875/843/101875843.geojson
+++ b/data/101/875/843/101875843.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Nov\u00e1 \u013dubov\u0148a"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"860154963e7e9b90690196f92787963f",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101875843,
-    "wof:lastmodified":1566645695,
+    "wof:lastmodified":1582382506,
     "wof:name":"Nov\u00e1 \u013dubov\u0148a",
     "wof:parent_id":102080611,
     "wof:placetype":"locality",

--- a/data/101/912/375/101912375.geojson
+++ b/data/101/912/375/101912375.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":1153001
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"387be89081a9547be55920636eac3ba3",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":101912375,
-    "wof:lastmodified":1566645730,
+    "wof:lastmodified":1582382510,
     "wof:name":"Dvor \u010cierna Voda",
     "wof:parent_id":102080465,
     "wof:placetype":"locality",

--- a/data/101/912/377/101912377.geojson
+++ b/data/101/912/377/101912377.geojson
@@ -111,6 +111,9 @@
         "wd:id":"Q1037257"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7621e01fa54bad0f6251dbf983fefe14",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101912377,
-    "wof:lastmodified":1566645730,
+    "wof:lastmodified":1582382510,
     "wof:name":"Hodrusa-Hamre",
     "wof:parent_id":102080499,
     "wof:placetype":"locality",

--- a/data/101/912/443/101912443.geojson
+++ b/data/101/912/443/101912443.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":1323398
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"22b5f66350816894f120626ff76a7252",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":101912443,
-    "wof:lastmodified":1566645730,
+    "wof:lastmodified":1582382510,
     "wof:name":"Alzbetin Dvor",
     "wof:parent_id":102080465,
     "wof:placetype":"locality",

--- a/data/101/913/487/101913487.geojson
+++ b/data/101/913/487/101913487.geojson
@@ -52,6 +52,9 @@
         "wd:id":"Q4321631"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76aff4099fc7dca738e4b15d2f6a698c",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101913487,
-    "wof:lastmodified":1527688566,
+    "wof:lastmodified":1582382513,
     "wof:name":"Berg",
     "wof:parent_id":102080455,
     "wof:placetype":"locality",

--- a/data/101/913/495/101913495.geojson
+++ b/data/101/913/495/101913495.geojson
@@ -651,6 +651,9 @@
         "wk:page":"Bratislava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"335fcbac2f470f79f721fd7b9c39b834",
     "wof:hierarchy":[
         {
@@ -665,7 +668,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1537317601,
+    "wof:lastmodified":1582382513,
     "wof:megacity":0,
     "wof:name":"Bratislava",
     "wof:parent_id":102080451,

--- a/data/101/913/501/101913501.geojson
+++ b/data/101/913/501/101913501.geojson
@@ -213,6 +213,9 @@
         "qs_pg:id":145217
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7d661e2d6691df9cec7a0381dfeae73",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
         }
     ],
     "wof:id":101913501,
-    "wof:lastmodified":1566645773,
+    "wof:lastmodified":1582382513,
     "wof:name":"Kom\u00e1rno",
     "wof:parent_id":102080447,
     "wof:placetype":"locality",

--- a/data/856/337/69/85633769.geojson
+++ b/data/856/337/69/85633769.geojson
@@ -1056,7 +1056,6 @@
     "qs:source":"EuroGlobalMap",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1129,7 +1128,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1582382502,
+    "wof:lastmodified":1583261341,
     "wof:name":"Slovakia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/337/69/85633769.geojson
+++ b/data/856/337/69/85633769.geojson
@@ -1056,6 +1056,7 @@
     "qs:source":"EuroGlobalMap",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1110,6 +1111,10 @@
     },
     "wof:country":"SK",
     "wof:country_alpha3":"SVK",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"21d1d3af37fda820fbeb8e1fae9c8be4",
     "wof:hierarchy":[
         {
@@ -1124,7 +1129,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1566645446,
+    "wof:lastmodified":1582382502,
     "wof:name":"Slovakia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/859/013/49/85901349.geojson
+++ b/data/859/013/49/85901349.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Ko\u0161ice-Barca"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b72675b13d6ec0daa64ac905b6a0c44c",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1534379461,
+    "wof:lastmodified":1582382501,
     "wof:name":"Barca",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/51/85901351.geojson
+++ b/data/859/013/51/85901351.geojson
@@ -134,6 +134,10 @@
         "wk:page":"\u010cunovo"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b3d2a40ddfb31041b8c62bffb0cde77",
     "wof:hierarchy":[
         {
@@ -149,7 +153,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645442,
+    "wof:lastmodified":1582382501,
     "wof:name":"\u010cunovo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/53/85901353.geojson
+++ b/data/859/013/53/85901353.geojson
@@ -138,6 +138,11 @@
         "wk:page":"Dev\u00ednska Nov\u00e1 Ves"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg",
+        "mz"
+    ],
     "wof:geomhash":"b6821820302c73d2f353ae2f788776ca",
     "wof:hierarchy":[
         {
@@ -153,7 +158,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645443,
+    "wof:lastmodified":1582382501,
     "wof:name":"Dev\u00ednska Nov\u00e1 Ves",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/57/85901357.geojson
+++ b/data/859/013/57/85901357.geojson
@@ -153,6 +153,10 @@
         "wk:page":"D\u00fabravka, Bratislava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2dc64f8b7c9a10316f6e4ba5b2f9776",
     "wof:hierarchy":[
         {
@@ -168,7 +172,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645441,
+    "wof:lastmodified":1582382501,
     "wof:name":"D\u00fabravka",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/59/85901359.geojson
+++ b/data/859/013/59/85901359.geojson
@@ -137,6 +137,11 @@
         "wd:id":"Q1091778"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3adf8f393a5593310e699b650da9310f",
     "wof:hierarchy":[
         {
@@ -152,7 +157,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645441,
+    "wof:lastmodified":1582382501,
     "wof:name":"Vajnory",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/61/85901361.geojson
+++ b/data/859/013/61/85901361.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":287276
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2788204495344e452065f5ed2e3e0f76",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645441,
+    "wof:lastmodified":1582382500,
     "wof:name":"Jahodn\u00edky",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/63/85901363.geojson
+++ b/data/859/013/63/85901363.geojson
@@ -163,6 +163,10 @@
         "wk:page":"Jarovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"823feabe9e87042606b2cc20064efd59",
     "wof:hierarchy":[
         {
@@ -178,7 +182,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645443,
+    "wof:lastmodified":1582382501,
     "wof:name":"Jarovce",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/65/85901365.geojson
+++ b/data/859/013/65/85901365.geojson
@@ -130,6 +130,11 @@
         "wk:page":"Karlova Ves"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg",
+        "mz"
+    ],
     "wof:geomhash":"74513d1d8b5f96f6a69cd874a7921d3e",
     "wof:hierarchy":[
         {
@@ -145,7 +150,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645443,
+    "wof:lastmodified":1582382501,
     "wof:name":"Karlova Ves",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/67/85901367.geojson
+++ b/data/859/013/67/85901367.geojson
@@ -127,6 +127,10 @@
         "wk:page":"Kave\u010dany"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e28f189be10ae9a477fa051875e13d26",
     "wof:hierarchy":[
         {
@@ -142,7 +146,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645442,
+    "wof:lastmodified":1582382501,
     "wof:name":"Kavecany",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/69/85901369.geojson
+++ b/data/859/013/69/85901369.geojson
@@ -90,6 +90,10 @@
         "wd:id":"Q277852"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6252e8861dd26debef0d59743d27bab",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645442,
+    "wof:lastmodified":1582382501,
     "wof:name":"Koliba",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/71/85901371.geojson
+++ b/data/859/013/71/85901371.geojson
@@ -127,6 +127,11 @@
         "wk:page":"Lama\u010d"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"09ac36c04d461920510e3f6a3865d7fd",
     "wof:hierarchy":[
         {
@@ -142,7 +147,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645444,
+    "wof:lastmodified":1582382501,
     "wof:name":"Lama\u010d",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/75/85901375.geojson
+++ b/data/859/013/75/85901375.geojson
@@ -106,6 +106,11 @@
         "qs_pg:id":184176
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg",
+        "mz"
+    ],
     "wof:geomhash":"07ef961f2f317e0ef9c028a49731c948",
     "wof:hierarchy":[
         {
@@ -121,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645443,
+    "wof:lastmodified":1582382501,
     "wof:name":"Nivy",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/77/85901377.geojson
+++ b/data/859/013/77/85901377.geojson
@@ -130,6 +130,11 @@
         "wk:page":"Nov\u00e9 Mesto, Bratislava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"d13e21859092c3007bf5b7d6e9d57617",
     "wof:hierarchy":[
         {
@@ -145,7 +150,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645444,
+    "wof:lastmodified":1582382501,
     "wof:name":"Nov\u00e9 Mesto",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/79/85901379.geojson
+++ b/data/859/013/79/85901379.geojson
@@ -82,6 +82,11 @@
         "qs_pg:id":1159089
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"0c7ada6820bec94bc13968610ef349b4",
     "wof:hierarchy":[
         {
@@ -97,7 +102,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645443,
+    "wof:lastmodified":1582382501,
     "wof:name":"Ovsi\u00b5te",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/81/85901381.geojson
+++ b/data/859/013/81/85901381.geojson
@@ -147,6 +147,11 @@
         "wk:page":"Petr\u017ealka"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg",
+        "mz"
+    ],
     "wof:geomhash":"902ed7b73ce56fff540bfd74d9d599a5",
     "wof:hierarchy":[
         {
@@ -162,7 +167,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645443,
+    "wof:lastmodified":1582382501,
     "wof:name":"Petr\u017ealka",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/83/85901383.geojson
+++ b/data/859/013/83/85901383.geojson
@@ -119,6 +119,11 @@
         "qs_pg:id":1153006
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "mz",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"118126152c6e1c3c3fe9509672aa206a",
     "wof:hierarchy":[
         {
@@ -134,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645444,
+    "wof:lastmodified":1582382501,
     "wof:name":"Ra\u010da",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/85/85901385.geojson
+++ b/data/859/013/85/85901385.geojson
@@ -155,6 +155,11 @@
         "wk:page":"Rusovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"94292f306858571ffb8446b58a64f491",
     "wof:hierarchy":[
         {
@@ -170,7 +175,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645444,
+    "wof:lastmodified":1582382501,
     "wof:name":"Rusovce",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/87/85901387.geojson
+++ b/data/859/013/87/85901387.geojson
@@ -138,6 +138,11 @@
         "wk:page":"Old Town, Bratislava"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "mz",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f28dd4866a623083efb3c411b2e323da",
     "wof:hierarchy":[
         {
@@ -153,7 +158,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645442,
+    "wof:lastmodified":1582382501,
     "wof:name":"Star\u00e9 Mesto",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/89/85901389.geojson
+++ b/data/859/013/89/85901389.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":962779
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"27e046c1ffa895b4e655214baa28bdfa",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645442,
+    "wof:lastmodified":1582382501,
     "wof:name":"Strohh\u00fcte",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/93/85901393.geojson
+++ b/data/859/013/93/85901393.geojson
@@ -115,6 +115,9 @@
         "wk:page":"\u0164ahanovce"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d784fd7d11137ddb9e7d6d53a808a50",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1534379461,
+    "wof:lastmodified":1582382501,
     "wof:name":"Tahanovce",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/95/85901395.geojson
+++ b/data/859/013/95/85901395.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":894062
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a03b61dc1068c90a0f93934eddf87a2d",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645441,
+    "wof:lastmodified":1582382501,
     "wof:name":"Tranka",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/97/85901397.geojson
+++ b/data/859/013/97/85901397.geojson
@@ -119,6 +119,10 @@
         "gp:id":822726
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"396c52b4c052ebfab946ff3edb9714ef",
     "wof:hierarchy":[
         {
@@ -134,7 +138,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645443,
+    "wof:lastmodified":1582382501,
     "wof:name":"Trn\u00e1vka",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/013/99/85901399.geojson
+++ b/data/859/013/99/85901399.geojson
@@ -112,6 +112,11 @@
         "qs_pg:id":184301
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"471929ce6c9bafe98860e77740e4abdc",
     "wof:hierarchy":[
         {
@@ -127,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645443,
+    "wof:lastmodified":1582382501,
     "wof:name":"Vinohrady",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/01/85901401.geojson
+++ b/data/859/014/01/85901401.geojson
@@ -131,6 +131,11 @@
         "wk:page":"Vraku\u0148a"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "mz",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"91c1057b02258f92d97ece3e12f65566",
     "wof:hierarchy":[
         {
@@ -146,7 +151,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645445,
+    "wof:lastmodified":1582382501,
     "wof:name":"Vraku\u0148a",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/03/85901403.geojson
+++ b/data/859/014/03/85901403.geojson
@@ -138,6 +138,11 @@
         "wk:page":"Z\u00e1horsk\u00e1 Bystrica"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46a51ad2698a8ef0dba973ba9da037f5",
     "wof:hierarchy":[
         {
@@ -153,7 +158,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645445,
+    "wof:lastmodified":1582382501,
     "wof:name":"Z\u00e1horsk\u00e1 Bystrica",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/288/01/85928801.geojson
+++ b/data/859/288/01/85928801.geojson
@@ -165,6 +165,10 @@
         "wk:page":"Dev\u00edn"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ce3a944415c19437bec013bcafb28a5",
     "wof:hierarchy":[
         {
@@ -180,7 +184,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645445,
+    "wof:lastmodified":1582382501,
     "wof:name":"Dev\u00edn",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/296/75/85929675.geojson
+++ b/data/859/296/75/85929675.geojson
@@ -133,6 +133,11 @@
         "wd:id":"Q934473"
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"80ee1203a918a5ec0eaceec31a188fdd",
     "wof:hierarchy":[
         {
@@ -148,7 +153,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645445,
+    "wof:lastmodified":1582382501,
     "wof:name":"Ru\u017einov",
     "wof:parent_id":1108800123,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/07/85929707.geojson
+++ b/data/859/297/07/85929707.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":473265
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"23861c0dc3ee57afa91522a62fbd0e1c",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645445,
+    "wof:lastmodified":1582382501,
     "wof:name":"Star\u00e9 Mesto",
     "wof:parent_id":101752055,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/11/85929711.geojson
+++ b/data/859/297/11/85929711.geojson
@@ -99,6 +99,10 @@
         "qs_pg:id":213529
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f61650e0bba4781f357789148966b75f",
     "wof:hierarchy":[
         {
@@ -114,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645445,
+    "wof:lastmodified":1582382501,
     "wof:name":"Dargovsk\u00fdch hrdinov",
     "wof:parent_id":101752055,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/15/85929715.geojson
+++ b/data/859/297/15/85929715.geojson
@@ -105,6 +105,10 @@
         "qs_pg:id":961088
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b251ef602edb24554c748fe3e9c109ef",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645446,
+    "wof:lastmodified":1582382502,
     "wof:name":"D\u017eungla",
     "wof:parent_id":101752055,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/19/85929719.geojson
+++ b/data/859/297/19/85929719.geojson
@@ -96,6 +96,10 @@
         "qs_pg:id":1334755
     },
     "wof:country":"SK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"311d5e67a235f9e926e3df11ec931f1d",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645445,
+    "wof:lastmodified":1582382501,
     "wof:name":"Nad jazerom",
     "wof:parent_id":101752055,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.