### PR TITLE
Name updates

### DIFF
--- a/data/856/337/69/85633769.geojson
+++ b/data/856/337/69/85633769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.986543,
-    "geom:area_square_m":48848374848.352463,
+    "geom:area_square_m":48848375151.957825,
     "geom:bbox":"16.832695,47.7313,22.569116,49.609993",
     "geom:latitude":48.707068,
     "geom:longitude":19.483743,
@@ -60,6 +60,9 @@
     "name:arg_x_preferred":[
         "Eslovaquia"
     ],
+    "name:ary_x_preferred":[
+        "\u0635\u0644\u0648\u06a4\u0627\u0643\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0633\u0644\u0648\u0641\u0627\u0643\u064a\u0627"
     ],
@@ -83,6 +86,9 @@
     ],
     "name:bam_x_preferred":[
         "Slowaki"
+    ],
+    "name:ban_x_preferred":[
+        "Slovakia"
     ],
     "name:bar_x_preferred":[
         "Slowakai"
@@ -189,6 +195,12 @@
     "name:dan_x_variant":[
         "Slovakiet (Den Slovakiske Republik)"
     ],
+    "name:deu_at_x_preferred":[
+        "Slowakei"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Slowakei"
+    ],
     "name:deu_x_preferred":[
         "Slowakei"
     ],
@@ -210,6 +222,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03bb\u03bf\u03b2\u03b1\u03ba\u03af\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Slovakia"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Slovakia"
     ],
     "name:eng_x_preferred":[
         "Slovakia"
@@ -284,6 +302,9 @@
     ],
     "name:gag_x_preferred":[
         "Slovakiya"
+    ],
+    "name:gcr_x_preferred":[
+        "Slovaki"
     ],
     "name:gla_x_preferred":[
         "An t-Sl\u00f2bhac"
@@ -691,6 +712,9 @@
     "name:pol_x_preferred":[
         "S\u0142owacja"
     ],
+    "name:por_br_x_preferred":[
+        "Eslov\u00e1quia"
+    ],
     "name:por_x_preferred":[
         "Eslov\u00e1quia"
     ],
@@ -742,6 +766,9 @@
     "name:san_x_preferred":[
         "\u0938\u094d\u0932\u094b\u0935\u093e\u0915\u093f\u092f\u093e"
     ],
+    "name:sat_x_preferred":[
+        "\u1c65\u1c5e\u1c73\u1c75\u1c77\u1c5f\u1c60\u1c64\u1c6d\u1c5f"
+    ],
     "name:scn_x_preferred":[
         "Slovacchia"
     ],
@@ -773,8 +800,14 @@
     "name:sme_x_variant":[
         "Slov\u00e1kia"
     ],
+    "name:smo_x_preferred":[
+        "Solovakia"
+    ],
     "name:sna_x_preferred":[
         "Slovakia"
+    ],
+    "name:snd_x_preferred":[
+        "\u0633\u0644\u0648\u0648\u0627\u06aa\u064a\u0627"
     ],
     "name:som_x_preferred":[
         "Islofaakiya"
@@ -803,6 +836,12 @@
     "name:srn_x_preferred":[
         "Slovakikondre"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0421\u043b\u043e\u0432\u0430\u0447\u043a\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Slova\u010dka"
+    ],
     "name:srp_x_preferred":[
         "\u0421\u043b\u043e\u0432\u0430\u0447\u043a\u0430"
     ],
@@ -823,6 +862,9 @@
     ],
     "name:szl_x_preferred":[
         "S\u0142owacyjo"
+    ],
+    "name:szy_x_preferred":[
+        "Slovakia"
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bbf\u0bb2\u0bcb\u0bb5\u0bbe\u0b95\u0bcd\u0b95\u0bbf\u0baf\u0bbe"
@@ -963,8 +1005,26 @@
     "name:zha_x_preferred":[
         "Slovakia"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u65af\u6d1b\u4f10\u514b"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u65af\u6d1b\u4f10\u514b"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Slovensko"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u65af\u6d1b\u4f10\u514b"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u65af\u6d1b\u4f10\u514b"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u65af\u6d1b\u4f10\u514b"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u65af\u6d1b\u4f10\u514b"
     ],
     "name:zho_x_preferred":[
         "\u65af\u6d1b\u4f10\u514b"
@@ -1129,7 +1189,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1583797434,
+    "wof:lastmodified":1587427833,
     "wof:name":"Slovakia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.