### PR TITLE
sk concordances, placetype local, and more

### DIFF
--- a/data/102/080/447/102080447.geojson
+++ b/data/102/080/447/102080447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.132193,
-    "geom:area_square_m":1097144551.822996,
+    "geom:area_square_m":1097143933.904494,
     "geom:bbox":"17.70824,47.7313,18.53464,47.986278",
     "geom:latitude":47.839882,
     "geom:longitude":18.112758,
@@ -172,10 +172,15 @@
     "wof:concordances":{
         "gp:id":29399355,
         "hasc:id":"SK.NI.KN",
+        "qs:local_id":"231",
         "wd:id":"Q586056"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"c4ea5671d8429e4758fba9dd36d6672c",
+    "wof:geomhash":"2449ab8be3252b77806bb5fbef92a401",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -185,7 +190,7 @@
         }
     ],
     "wof:id":102080447,
-    "wof:lastmodified":1690865435,
+    "wof:lastmodified":1695886351,
     "wof:name":"Kom\u00e1rno",
     "wof:parent_id":85688365,
     "wof:placetype":"county",

--- a/data/102/080/449/102080449.geojson
+++ b/data/102/080/449/102080449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011382,
-    "geom:area_square_m":94051425.873733,
+    "geom:area_square_m":94051578.791776,
     "geom:bbox":"17.05686,48.006714,17.24177,48.143109",
     "geom:latitude":48.068605,
     "geom:longitude":17.131189,
@@ -221,10 +221,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BL.B5",
+        "qs:local_id":"105",
         "wd:id":"Q750439"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"bd509c5bd5e9db726bc649c41ee38acc",
+    "wof:geomhash":"8801ab5fcddde575aade53adc1678a29",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -234,7 +239,7 @@
         }
     ],
     "wof:id":102080449,
-    "wof:lastmodified":1690865435,
+    "wof:lastmodified":1695886352,
     "wof:name":"Bratislava V",
     "wof:parent_id":85688373,
     "wof:placetype":"county",

--- a/data/102/080/453/102080453.geojson
+++ b/data/102/080/453/102080453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129425,
-    "geom:area_square_m":1071421202.90095,
+    "geom:area_square_m":1071421319.899702,
     "geom:bbox":"17.246883,47.757096,17.888936,48.174104",
     "geom:latitude":47.972553,
     "geom:longitude":17.584324,
@@ -174,10 +174,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TA.DS",
+        "qs:local_id":"211",
         "wd:id":"Q756662"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"d792ba60c65ab828776169a6ebbb273b",
+    "wof:geomhash":"1a13ff992f34937af3b14daf0b7729a9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":102080453,
-    "wof:lastmodified":1690865438,
+    "wof:lastmodified":1695886353,
     "wof:name":"Dunajsk\u00e1 Streda",
     "wof:parent_id":85688369,
     "wof:placetype":"county",

--- a/data/102/080/455/102080455.geojson
+++ b/data/102/080/455/102080455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011172,
-    "geom:area_square_m":92209319.902569,
+    "geom:area_square_m":92209331.434981,
     "geom:bbox":"17.117379,48.053793,17.284549,48.191746",
     "geom:latitude":48.127944,
     "geom:longitude":17.193068,
@@ -221,10 +221,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BL.B2",
+        "qs:local_id":"102",
         "wd:id":"Q539732"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"9f9b022a680f8d1e58ea23ecb4b4d1f9",
+    "wof:geomhash":"c2a0ede2b2d9b652a3b1b6a806e8695c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -234,7 +239,7 @@
         }
     ],
     "wof:id":102080455,
-    "wof:lastmodified":1690865437,
+    "wof:lastmodified":1695886353,
     "wof:name":"Bratislava II",
     "wof:parent_id":85688373,
     "wof:placetype":"county",

--- a/data/102/080/459/102080459.geojson
+++ b/data/102/080/459/102080459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009041,
-    "geom:area_square_m":74510538.70403,
+    "geom:area_square_m":74510536.445284,
     "geom:bbox":"17.063981,48.156066,17.231615,48.244548",
     "geom:latitude":48.201348,
     "geom:longitude":17.137249,
@@ -221,10 +221,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BL.B3",
+        "qs:local_id":"103",
         "wd:id":"Q750419"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"bebfae132905d72b0f0f3616e53007bf",
+    "wof:geomhash":"58209762288067a28097b16e9892a35e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -234,7 +239,7 @@
         }
     ],
     "wof:id":102080459,
-    "wof:lastmodified":1690865446,
+    "wof:lastmodified":1695886357,
     "wof:name":"Bratislava III",
     "wof:parent_id":85688373,
     "wof:placetype":"county",

--- a/data/102/080/461/102080461.geojson
+++ b/data/102/080/461/102080461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011643,
-    "geom:area_square_m":95949147.11899,
+    "geom:area_square_m":95949080.5375,
     "geom:bbox":"16.946163,48.139736,17.137226,48.265059",
     "geom:latitude":48.206216,
     "geom:longitude":17.024533,
@@ -221,10 +221,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BL.B4",
+        "qs:local_id":"104",
         "wd:id":"Q750416"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"86af4b5f66debcc20c1ca6e1ffd7b368",
+    "wof:geomhash":"eef22be86ef87a32cfa96bceefe55d8b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -234,7 +239,7 @@
         }
     ],
     "wof:id":102080461,
-    "wof:lastmodified":1690865446,
+    "wof:lastmodified":1695886357,
     "wof:name":"Bratislava IV",
     "wof:parent_id":85688373,
     "wof:placetype":"county",

--- a/data/102/080/463/102080463.geojson
+++ b/data/102/080/463/102080463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162229,
-    "geom:area_square_m":1342577269.697085,
+    "geom:area_square_m":1342577654.052625,
     "geom:bbox":"17.961031,47.755383,18.85606,48.206856",
     "geom:latitude":47.988012,
     "geom:longitude":18.361034,
@@ -182,10 +182,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.NI.NZ",
+        "qs:local_id":"234",
         "wd:id":"Q730722"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"ce0dc09010ce999cf3888740fc608cfe",
+    "wof:geomhash":"26a89956a2ceb47817645a33d39f1970",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -195,7 +200,7 @@
         }
     ],
     "wof:id":102080463,
-    "wof:lastmodified":1690865437,
+    "wof:lastmodified":1695886353,
     "wof:name":"Nov\u00e9 Z\u00e1mky",
     "wof:parent_id":85688365,
     "wof:placetype":"county",

--- a/data/102/080/465/102080465.geojson
+++ b/data/102/080/465/102080465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043514,
-    "geom:area_square_m":358777181.622172,
+    "geom:area_square_m":358777200.846657,
     "geom:bbox":"17.187392,48.011765,17.529213,48.310542",
     "geom:latitude":48.179443,
     "geom:longitude":17.352379,
@@ -176,10 +176,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BL.SC",
+        "qs:local_id":"108",
         "wd:id":"Q513989"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"18476b42a977f6ef02bbc1ee71732d17",
+    "wof:geomhash":"4f26c3663720d99906b52cdc65937687",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -189,7 +194,7 @@
         }
     ],
     "wof:id":102080465,
-    "wof:lastmodified":1690865438,
+    "wof:lastmodified":1695886353,
     "wof:name":"Senec",
     "wof:parent_id":85688373,
     "wof:placetype":"county",

--- a/data/102/080/467/102080467.geojson
+++ b/data/102/080/467/102080467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042992,
-    "geom:area_square_m":354858910.384173,
+    "geom:area_square_m":354858968.983498,
     "geom:bbox":"17.754777,47.962946,18.019046,48.284574",
     "geom:latitude":48.123501,
     "geom:longitude":17.909557,
@@ -65,10 +65,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.NI.SA"
+        "hasc:id":"SK.NI.SA",
+        "qs:local_id":"235"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"4ba9e106c3d30d3fef1d76f76c0d5e52",
+    "wof:geomhash":"012b8950146015041862a1b5b5554a9e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -78,7 +83,7 @@
         }
     ],
     "wof:id":102080467,
-    "wof:lastmodified":1627522780,
+    "wof:lastmodified":1695886473,
     "wof:name":"\u0160ala",
     "wof:parent_id":85688365,
     "wof:placetype":"county",

--- a/data/102/080/469/102080469.geojson
+++ b/data/102/080/469/102080469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077595,
-    "geom:area_square_m":639776188.358084,
+    "geom:area_square_m":639776071.198205,
     "geom:bbox":"17.466656,47.960394,17.884482,48.355154",
     "geom:latitude":48.179799,
     "geom:longitude":17.702799,
@@ -177,10 +177,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TA.GA",
+        "qs:local_id":"212",
         "wd:id":"Q836182"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"29371a0d24a09e45fb21f078a2a541b4",
+    "wof:geomhash":"ae26dd3dbdd6235c5b252bea3363dc40",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":102080469,
-    "wof:lastmodified":1690865445,
+    "wof:lastmodified":1695886357,
     "wof:name":"Galanta",
     "wof:parent_id":85688369,
     "wof:placetype":"county",

--- a/data/102/080/471/102080471.geojson
+++ b/data/102/080/471/102080471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045535,
-    "geom:area_square_m":374324159.052978,
+    "geom:area_square_m":374324159.052969,
     "geom:bbox":"17.1342405,48.203953,17.477537,48.4563095",
     "geom:latitude":48.331705,
     "geom:longitude":17.304652,
@@ -170,10 +170,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.BL.PK"
+        "hasc:id":"SK.BL.PK",
+        "qs:local_id":"107"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"15126e2f1480cee60c2414caae289ffd",
+    "wof:geomhash":"68eedfbf06cd6f53c5fa2346c0c0d4fa",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -183,7 +188,7 @@
         }
     ],
     "wof:id":102080471,
-    "wof:lastmodified":1566645370,
+    "wof:lastmodified":1695886352,
     "wof:name":"Pezinok",
     "wof:parent_id":85688373,
     "wof:placetype":"county",

--- a/data/102/080/473/102080473.geojson
+++ b/data/102/080/473/102080473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105529,
-    "geom:area_square_m":867979224.545036,
+    "geom:area_square_m":867979370.113401,
     "geom:bbox":"17.832964,48.1413,18.438635,48.464728",
     "geom:latitude":48.304185,
     "geom:longitude":18.10905,
@@ -171,10 +171,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.NI.NR",
+        "qs:local_id":"233",
         "wd:id":"Q761574"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"700543b15a9b32316491b0cfc770cfad",
+    "wof:geomhash":"6289f888eb42b862a5a152e8d7a4785c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":102080473,
-    "wof:lastmodified":1690865445,
+    "wof:lastmodified":1695886356,
     "wof:name":"Nitra",
     "wof:parent_id":85688365,
     "wof:placetype":"county",

--- a/data/102/080/477/102080477.geojson
+++ b/data/102/080/477/102080477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187462,
-    "geom:area_square_m":1546444067.016339,
+    "geom:area_square_m":1546443776.511142,
     "geom:bbox":"18.343336,47.932024,19.072128,48.416778",
     "geom:latitude":48.15291,
     "geom:longitude":18.670923,
@@ -174,10 +174,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.NI.LV",
+        "qs:local_id":"232",
         "wd:id":"Q777394"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"f6f0bb4deca0f70a389e9f7169865030",
+    "wof:geomhash":"8ac735c0e45f818bbe8451784af3a437",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":102080477,
-    "wof:lastmodified":1690865436,
+    "wof:lastmodified":1695886352,
     "wof:name":"Levice",
     "wof:parent_id":85688365,
     "wof:placetype":"county",

--- a/data/102/080/479/102080479.geojson
+++ b/data/102/080/479/102080479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102619,
-    "geom:area_square_m":845842249.326488,
+    "geom:area_square_m":845842249.326463,
     "geom:bbox":"19.012154,48.053829,19.564039,48.3983285",
     "geom:latitude":48.195271,
     "geom:longitude":19.304461,
@@ -92,10 +92,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.BC.VK"
+        "hasc:id":"SK.BC.VK",
+        "qs:local_id":"32A"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"d69776f8e7eef2906ea291db9e92823f",
+    "wof:geomhash":"5b143bf86e515b5ce2b97aab0b7bd428",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -105,7 +110,7 @@
         }
     ],
     "wof:id":102080479,
-    "wof:lastmodified":1566645371,
+    "wof:lastmodified":1695886352,
     "wof:name":"Velk\u00fd Krt\u00ed\u0161",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/481/102080481.geojson
+++ b/data/102/080/481/102080481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032476,
-    "geom:area_square_m":266463396.115229,
+    "geom:area_square_m":266463523.060436,
     "geom:bbox":"17.679449,48.322197,17.964675,48.522003",
     "geom:latitude":48.428927,
     "geom:longitude":17.814278,
@@ -174,10 +174,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TA.HC",
+        "qs:local_id":"213",
         "wd:id":"Q550271"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"70a3996a84c4c5fb817f40de7a3a6888",
+    "wof:geomhash":"40e921d2159bfc8053b339c8c2105662",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":102080481,
-    "wof:lastmodified":1690865444,
+    "wof:lastmodified":1695886356,
     "wof:name":"Hlohovec",
     "wof:parent_id":85688369,
     "wof:placetype":"county",

--- a/data/102/080/483/102080483.geojson
+++ b/data/102/080/483/102080483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070882,
-    "geom:area_square_m":583165354.988433,
+    "geom:area_square_m":583165552.663498,
     "geom:bbox":"18.798404,48.156526,19.233807,48.440728",
     "geom:latitude":48.289945,
     "geom:longitude":19.021142,
@@ -177,10 +177,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BC.KA",
+        "qs:local_id":"325",
         "wd:id":"Q756660"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"fb1f6eb8b3aa3590a101235966779e3d",
+    "wof:geomhash":"1e8040ca7379f49eceb54d6f8723fc1c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":102080483,
-    "wof:lastmodified":1690865436,
+    "wof:lastmodified":1695886352,
     "wof:name":"Krupina",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/485/102080485.geojson
+++ b/data/102/080/485/102080485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063284,
-    "geom:area_square_m":519479252.399086,
+    "geom:area_square_m":519479252.39911,
     "geom:bbox":"18.190133,48.263957,18.576248,48.548604",
     "geom:latitude":48.405216,
     "geom:longitude":18.397131,
@@ -149,10 +149,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.NI.ZM"
+        "hasc:id":"SK.NI.ZM",
+        "qs:local_id":"237"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"b6097c4e98c5bcd78df729c432bff9d8",
+    "wof:geomhash":"dde5f588f0ccce6725cbff587faadde4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -162,7 +167,7 @@
         }
     ],
     "wof:id":102080485,
-    "wof:lastmodified":1566645370,
+    "wof:lastmodified":1695886352,
     "wof:name":"Zlat\u00e9 Moravce",
     "wof:parent_id":85688365,
     "wof:placetype":"county",

--- a/data/102/080/487/102080487.geojson
+++ b/data/102/080/487/102080487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115271,
-    "geom:area_square_m":945786927.505923,
+    "geom:area_square_m":945787016.523289,
     "geom:bbox":"16.832695,48.235615,17.376616,48.654027",
     "geom:latitude":48.428826,
     "geom:longitude":17.087264,
@@ -174,10 +174,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BL.MA",
+        "qs:local_id":"106",
         "wd:id":"Q590660"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"8382d2f0136c2eefc88dbb189c05d789",
+    "wof:geomhash":"5d8bfc59469432907f33ab6361569e8d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":102080487,
-    "wof:lastmodified":1690865444,
+    "wof:lastmodified":1695886356,
     "wof:name":"Malacky",
     "wof:parent_id":85688373,
     "wof:placetype":"county",

--- a/data/102/080/489/102080489.geojson
+++ b/data/102/080/489/102080489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090051,
-    "geom:area_square_m":738812792.529824,
+    "geom:area_square_m":738812568.279489,
     "geom:bbox":"17.302191,48.239763,17.758011,48.644796",
     "geom:latitude":48.432342,
     "geom:longitude":17.543351,
@@ -184,10 +184,15 @@
     "wof:concordances":{
         "gp:id":29399336,
         "hasc:id":"SK.TA.TT",
+        "qs:local_id":"217",
         "wd:id":"Q775484"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"69ee3a72d3a8ced7dfa9e2f0a7973f24",
+    "wof:geomhash":"e33b5d30d21bfdf356529d847ee6f2ec",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -197,7 +202,7 @@
         }
     ],
     "wof:id":102080489,
-    "wof:lastmodified":1690865445,
+    "wof:lastmodified":1695886356,
     "wof:name":"Trnava",
     "wof:parent_id":85688369,
     "wof:placetype":"county",

--- a/data/102/080/491/102080491.geojson
+++ b/data/102/080/491/102080491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035515,
-    "geom:area_square_m":291377892.619666,
+    "geom:area_square_m":291378032.117037,
     "geom:bbox":"18.750647,48.304981,19.015288,48.567344",
     "geom:latitude":48.432097,
     "geom:longitude":18.902406,
@@ -183,10 +183,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BC.BS",
+        "qs:local_id":"322",
         "wd:id":"Q836179"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"1f962c2876714275b0bd3a2638d36d38",
+    "wof:geomhash":"270738a07ee88c2bfedf77305f73e230",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":102080491,
-    "wof:lastmodified":1690865438,
+    "wof:lastmodified":1695886354,
     "wof:name":"Bansk\u00e1 \u0160tiavnica",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/495/102080495.geojson
+++ b/data/102/080/495/102080495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046447,
-    "geom:area_square_m":379937249.136822,
+    "geom:area_square_m":379937462.636592,
     "geom:bbox":"17.556982,48.472092,17.985486,48.682515",
     "geom:latitude":48.582811,
     "geom:longitude":17.742174,
@@ -95,10 +95,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.TA.PN"
+        "hasc:id":"SK.TA.PN",
+        "qs:local_id":"214"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"752b79bd5e26b8ecbbec2bf6e243ce1e",
+    "wof:geomhash":"5f16ba110c5662435859cfefefd31d08",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -108,7 +113,7 @@
         }
     ],
     "wof:id":102080495,
-    "wof:lastmodified":1627522780,
+    "wof:lastmodified":1695886473,
     "wof:name":"Pie\u0161tany",
     "wof:parent_id":85688369,
     "wof:placetype":"county",

--- a/data/102/080/497/102080497.geojson
+++ b/data/102/080/497/102080497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100142,
-    "geom:area_square_m":823094704.232697,
+    "geom:area_square_m":823094839.496848,
     "geom:bbox":"19.36355,48.15353,19.942685,48.545418",
     "geom:latitude":48.339941,
     "geom:longitude":19.646531,
@@ -66,10 +66,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29399361,
-        "hasc:id":"SK.BC.LC"
+        "hasc:id":"SK.BC.LC",
+        "qs:local_id":"326"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"f9723535f2c7261ef7bf02885d1f5e9c",
+    "wof:geomhash":"d00396fcdb96b7766763f77892697dc5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -79,7 +84,7 @@
         }
     ],
     "wof:id":102080497,
-    "wof:lastmodified":1627522780,
+    "wof:lastmodified":1695886473,
     "wof:name":"Lucenec",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/499/102080499.geojson
+++ b/data/102/080/499/102080499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051737,
-    "geom:area_square_m":424109555.308187,
+    "geom:area_square_m":424109555.308177,
     "geom:bbox":"18.478677,48.309816,18.8762005,48.633212",
     "geom:latitude":48.475663,
     "geom:longitude":18.647015,
@@ -137,10 +137,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.BC.ZC"
+        "hasc:id":"SK.BC.ZC",
+        "qs:local_id":"32C"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"f496f3849836f1141373e04dc722a61c",
+    "wof:geomhash":"84f5045014322ec1f1c5600b04fd6b6c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -150,7 +155,7 @@
         }
     ],
     "wof:id":102080499,
-    "wof:lastmodified":1566645372,
+    "wof:lastmodified":1695886353,
     "wof:name":"\u017darnovica",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/501/102080501.geojson
+++ b/data/102/080/501/102080501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072789,
-    "geom:area_square_m":595776003.269944,
+    "geom:area_square_m":595775678.058398,
     "geom:bbox":"17.844604,48.420517,18.312921,48.714432",
     "geom:latitude":48.552112,
     "geom:longitude":18.085781,
@@ -65,10 +65,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.NI.TO"
+        "hasc:id":"SK.NI.TO",
+        "qs:local_id":"236"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"5e4e65b53fd00c352d11df247c5bf425",
+    "wof:geomhash":"c7eea3351bf10a3cf6123cd4bb2fd76d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -78,7 +83,7 @@
         }
     ],
     "wof:id":102080501,
-    "wof:lastmodified":1627522780,
+    "wof:lastmodified":1695886473,
     "wof:name":"Topolcany",
     "wof:parent_id":85688365,
     "wof:placetype":"county",

--- a/data/102/080/503/102080503.geojson
+++ b/data/102/080/503/102080503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036682,
-    "geom:area_square_m":299983986.798975,
+    "geom:area_square_m":299984234.068113,
     "geom:bbox":"18.2083,48.485686,18.497977,48.704514",
     "geom:latitude":48.595337,
     "geom:longitude":18.358394,
@@ -171,10 +171,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TC.PE",
+        "qs:local_id":"225",
         "wd:id":"Q837871"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"4b8122bedb65cc8d1bff4fa8dcd13765",
+    "wof:geomhash":"ecf65d9496282baf74befd45feefae2e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":102080503,
-    "wof:lastmodified":1690865434,
+    "wof:lastmodified":1695886351,
     "wof:name":"Partiz\u00e1nske",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/505/102080505.geojson
+++ b/data/102/080/505/102080505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083322,
-    "geom:area_square_m":680779630.328821,
+    "geom:area_square_m":680779598.50661,
     "geom:bbox":"16.93375,48.506586,17.533132,48.787849",
     "geom:latitude":48.641817,
     "geom:longitude":17.248697,
@@ -168,10 +168,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TA.SE",
+        "qs:local_id":"215",
         "wd:id":"Q842557"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"097d945360a7f6ee6daf816a82085a0d",
+    "wof:geomhash":"9cd295c34bbf579e02e59b2b47bd36cd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":102080505,
-    "wof:lastmodified":1690865433,
+    "wof:lastmodified":1695886350,
     "wof:name":"Senica",
     "wof:parent_id":85688369,
     "wof:placetype":"county",

--- a/data/102/080/507/102080507.geojson
+++ b/data/102/080/507/102080507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054709,
-    "geom:area_square_m":447782055.368276,
+    "geom:area_square_m":447782069.241644,
     "geom:bbox":"19.237246,48.382389,19.72131,48.661487",
     "geom:latitude":48.553104,
     "geom:longitude":19.458958,
@@ -183,10 +183,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BC.DT",
+        "qs:local_id":"324",
         "wd:id":"Q532137"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"e5579d40aa077345d70e277da682bceb",
+    "wof:geomhash":"5231438b4d059c3e2e53c4c7f264d559",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":102080507,
-    "wof:lastmodified":1690865442,
+    "wof:lastmodified":1695886355,
     "wof:name":"Detva",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/509/102080509.geojson
+++ b/data/102/080/509/102080509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092388,
-    "geom:area_square_m":756770354.231829,
+    "geom:area_square_m":756770337.044226,
     "geom:bbox":"18.972909,48.28205,19.494567,48.684788",
     "geom:latitude":48.513827,
     "geom:longitude":19.185958,
@@ -183,10 +183,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BC.ZV",
+        "qs:local_id":"32B",
         "wd:id":"Q370161"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"42789c7bfa3aad1b739e447cc816fc30",
+    "wof:geomhash":"e81dc5190ba74914580920b0ef8a860a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":102080509,
-    "wof:lastmodified":1690865443,
+    "wof:lastmodified":1695886177,
     "wof:name":"Zvolen",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/513/102080513.geojson
+++ b/data/102/080/513/102080513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057926,
-    "geom:area_square_m":474671015.310512,
+    "geom:area_square_m":474671240.884848,
     "geom:bbox":"19.580465,48.360112,19.92751,48.648779",
     "geom:latitude":48.493902,
     "geom:longitude":19.754219,
@@ -175,10 +175,15 @@
     "wof:concordances":{
         "gp:id":29399333,
         "hasc:id":"SK.BC.PT",
+        "qs:local_id":"327",
         "wd:id":"Q256846"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"88330d6a18fe4d0e178a94a70bd25b25",
+    "wof:geomhash":"8ad73307afb439a5d2822a313eb24c79",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -188,7 +193,7 @@
         }
     ],
     "wof:id":102080513,
-    "wof:lastmodified":1690865447,
+    "wof:lastmodified":1695886358,
     "wof:name":"Polt\u00e1r",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/515/102080515.geojson
+++ b/data/102/080/515/102080515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040128,
-    "geom:area_square_m":327212997.548472,
+    "geom:area_square_m":327213446.538976,
     "geom:bbox":"17.353044,48.626616,17.720052,48.846561",
     "geom:latitude":48.741349,
     "geom:longitude":17.557615,
@@ -171,10 +171,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TC.MY",
+        "qs:local_id":"223",
         "wd:id":"Q733250"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"24224515a52589efa83c323c73487b9e",
+    "wof:geomhash":"6efc922b82da1ecfee6c52dce3267ca8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":102080515,
-    "wof:lastmodified":1690865448,
+    "wof:lastmodified":1695886359,
     "wof:name":"Myjava",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/517/102080517.geojson
+++ b/data/102/080/517/102080517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043876,
-    "geom:area_square_m":357559746.617121,
+    "geom:area_square_m":357559867.475288,
     "geom:bbox":"16.979816,48.670953,17.399425,48.878223",
     "geom:latitude":48.772609,
     "geom:longitude":17.190626,
@@ -171,10 +171,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TA.SI",
+        "qs:local_id":"216",
         "wd:id":"Q837894"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"c2e3784736e5a2e6f3e5c785c8fe02de",
+    "wof:geomhash":"74e6d6f7f39aed500e016f07a4581286",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":102080517,
-    "wof:lastmodified":1690865438,
+    "wof:lastmodified":1695886354,
     "wof:name":"Skalica",
     "wof:parent_id":85688369,
     "wof:placetype":"county",

--- a/data/102/080/519/102080519.geojson
+++ b/data/102/080/519/102080519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063161,
-    "geom:area_square_m":516245994.522413,
+    "geom:area_square_m":516246081.235244,
     "geom:bbox":"18.645412,48.477206,19.033439,48.76977",
     "geom:latitude":48.623005,
     "geom:longitude":18.85167,
@@ -193,10 +193,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BC.ZH",
+        "qs:local_id":"32D",
         "wd:id":"Q836194"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"a8c82dacdadf01ed655b5652e4e3dcaf",
+    "wof:geomhash":"61e31533f9d2d3700d86631362de3759",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -206,7 +211,7 @@
         }
     ],
     "wof:id":102080519,
-    "wof:lastmodified":1690865439,
+    "wof:lastmodified":1695886354,
     "wof:name":"\u017diar nad Hronom",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/521/102080521.geojson
+++ b/data/102/080/521/102080521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070941,
-    "geom:area_square_m":578296242.724929,
+    "geom:area_square_m":578295987.706467,
     "geom:bbox":"17.614073,48.611092,18.023364,48.92736",
     "geom:latitude":48.756955,
     "geom:longitude":17.822331,
@@ -159,10 +159,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TC.NM",
+        "qs:local_id":"224",
         "wd:id":"Q282702"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"aea04b7c61d686c5402ef52f39555049",
+    "wof:geomhash":"47554cdee7089a38fe81bdd037285044",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -172,7 +177,7 @@
         }
     ],
     "wof:id":102080521,
-    "wof:lastmodified":1690865439,
+    "wof:lastmodified":1695886354,
     "wof:name":"Nov\u00e9 Mesto nad V\u00e1hom",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/523/102080523.geojson
+++ b/data/102/080/523/102080523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056506,
-    "geom:area_square_m":460625025.102557,
+    "geom:area_square_m":460625012.050188,
     "geom:bbox":"17.997168,48.630635,18.439544,48.895263",
     "geom:latitude":48.757157,
     "geom:longitude":18.255791,
@@ -171,10 +171,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TC.BN",
+        "qs:local_id":"221",
         "wd:id":"Q837865"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"1d562cc3451d9a6767ad8c1eee2aa6a7",
+    "wof:geomhash":"dccc5b806662c8762a145240af264e66",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":102080523,
-    "wof:lastmodified":1690865448,
+    "wof:lastmodified":1695886359,
     "wof:name":"B\u00e1novce nad Bebravou",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/525/102080525.geojson
+++ b/data/102/080/525/102080525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178773,
-    "geom:area_square_m":1466763700.193033,
+    "geom:area_square_m":1466763589.453071,
     "geom:bbox":"19.728008,48.124748,20.420629,48.769584",
     "geom:latitude":48.430516,
     "geom:longitude":20.040921,
@@ -201,10 +201,15 @@
     "wof:concordances":{
         "gp:id":29399327,
         "hasc:id":"SK.BC.RS",
+        "qs:local_id":"329",
         "wd:id":"Q836188"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"caba3413fda94814b857456432f1d580",
+    "wof:geomhash":"9f2d4b404647fbdf9a4739c6b544d38f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -214,7 +219,7 @@
         }
     ],
     "wof:id":102080525,
-    "wof:lastmodified":1690865447,
+    "wof:lastmodified":1695886358,
     "wof:name":"Rimavsk\u00e1 Sobota",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/527/102080527.geojson
+++ b/data/102/080/527/102080527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08907,
-    "geom:area_square_m":728091472.366385,
+    "geom:area_square_m":728091150.938458,
     "geom:bbox":"19.885807,48.397616,20.46982,48.806726",
     "geom:latitude":48.617498,
     "geom:longitude":20.175813,
@@ -174,10 +174,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BC.RA",
+        "qs:local_id":"328",
         "wd:id":"Q651878"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"0f76e4d4d1e6cfff72e477df244cd506",
+    "wof:geomhash":"1e32986c67ce5edc6704af3455d37019",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":102080527,
-    "wof:lastmodified":1690865440,
+    "wof:lastmodified":1695886354,
     "wof:name":"Rev\u00faca",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/531/102080531.geojson
+++ b/data/102/080/531/102080531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098991,
-    "geom:area_square_m":806897858.60304,
+    "geom:area_square_m":806897843.911316,
     "geom:bbox":"18.991117,48.618924,19.504472,48.898136",
     "geom:latitude":48.760395,
     "geom:longitude":19.229348,
@@ -192,10 +192,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BC.BB",
+        "qs:local_id":"321",
         "wd:id":"Q539934"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"917088fda76a90d6b214bdbe82a53e84",
+    "wof:geomhash":"dc8c562c09f586adb777d6a496591303",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -205,7 +210,7 @@
         }
     ],
     "wof:id":102080531,
-    "wof:lastmodified":1690865443,
+    "wof:lastmodified":1695886356,
     "wof:name":"Bansk\u00e1 Bystrica",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/533/102080533.geojson
+++ b/data/102/080/533/102080533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009826,
-    "geom:area_square_m":80270524.529613,
+    "geom:area_square_m":80270336.22257,
     "geom:bbox":"21.12079,48.570036,21.248777,48.733272",
     "geom:latitude":48.647834,
     "geom:longitude":21.1943,
@@ -222,10 +222,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.K2",
+        "qs:local_id":"423",
         "wd:id":"Q280424"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"0baf2db99422af9e6b1f51214ffb10fc",
+    "wof:geomhash":"071206e607bd1a6ff408039b7679f855",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":102080533,
-    "wof:lastmodified":1690865433,
+    "wof:lastmodified":1695886351,
     "wof:name":"Ko\u0161ice II",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/535/102080535.geojson
+++ b/data/102/080/535/102080535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007446,
-    "geom:area_square_m":60789110.870979,
+    "geom:area_square_m":60789106.358158,
     "geom:bbox":"21.211491,48.641717,21.358201,48.726641",
     "geom:latitude":48.679912,
     "geom:longitude":21.285073,
@@ -222,10 +222,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.K4",
+        "qs:local_id":"425",
         "wd:id":"Q650575"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"e0e8a38e4437f994e7e15308617658d0",
+    "wof:geomhash":"f8d47552f535a5ce03d96827a833e870",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":102080535,
-    "wof:lastmodified":1690865435,
+    "wof:lastmodified":1695886351,
     "wof:name":"Ko\u0161ice IV",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/537/102080537.geojson
+++ b/data/102/080/537/102080537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117386,
-    "geom:area_square_m":956580349.840005,
+    "geom:area_square_m":956580137.045461,
     "geom:bbox":"18.324423,48.561328,18.82687,48.971453",
     "geom:latitude":48.773953,
     "geom:longitude":18.578155,
@@ -174,10 +174,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TC.PD",
+        "qs:local_id":"227",
         "wd:id":"Q614140"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"90367bf3063265b2c5ffc4d5d8570a55",
+    "wof:geomhash":"850a1786fd01fb7bf1c95e6c4c9626d8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":102080537,
-    "wof:lastmodified":1690865441,
+    "wof:lastmodified":1695886355,
     "wof:name":"Prievidza",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/539/102080539.geojson
+++ b/data/102/080/539/102080539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048137,
-    "geom:area_square_m":391661003.793626,
+    "geom:area_square_m":391661166.512591,
     "geom:bbox":"18.693193,48.741156,19.029293,48.966632",
     "geom:latitude":48.851539,
     "geom:longitude":18.85861,
@@ -65,10 +65,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.ZI.TR"
+        "hasc:id":"SK.ZI.TR",
+        "qs:local_id":"319"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"9350c7dce5765b2a6d705eb286fd4442",
+    "wof:geomhash":"5edfdaf555db6cb8a703821dcede4431",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -78,7 +83,7 @@
         }
     ],
     "wof:id":102080539,
-    "wof:lastmodified":1627522781,
+    "wof:lastmodified":1695886474,
     "wof:name":"Turcianske Teplice",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/541/102080541.geojson
+++ b/data/102/080/541/102080541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082773,
-    "geom:area_square_m":673022641.542378,
+    "geom:area_square_m":673022451.549371,
     "geom:bbox":"17.830727,48.73593,18.332521,49.059063",
     "geom:latitude":48.885345,
     "geom:longitude":18.049201,
@@ -65,10 +65,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.TC.TN"
+        "hasc:id":"SK.TC.TN",
+        "qs:local_id":"229"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"39756f912e0582e8cacf97c79f249b85",
+    "wof:geomhash":"4740ae0adc9380bc370bbe2ac57c3e5d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -78,7 +83,7 @@
         }
     ],
     "wof:id":102080541,
-    "wof:lastmodified":1627522780,
+    "wof:lastmodified":1695886473,
     "wof:name":"Trenc\u00edn",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/543/102080543.geojson
+++ b/data/102/080/543/102080543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002063,
-    "geom:area_square_m":16822908.81307,
+    "geom:area_square_m":16822987.79462,
     "geom:bbox":"21.265964,48.711865,21.330001,48.785825",
     "geom:latitude":48.740712,
     "geom:longitude":21.298492,
@@ -222,10 +222,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.K3",
+        "qs:local_id":"424",
         "wd:id":"Q548619"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"2da3ed2c2cebb668ef4d7887477051f3",
+    "wof:geomhash":"afcfb853b0b72df6d9cf1edcc032ebfd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":102080543,
-    "wof:lastmodified":1690865439,
+    "wof:lastmodified":1695886354,
     "wof:name":"Ko\u0161ice III",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/545/102080545.geojson
+++ b/data/102/080/545/102080545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15494,
-    "geom:area_square_m":1261619900.335193,
+    "geom:area_square_m":1261619946.044725,
     "geom:bbox":"19.350431,48.619161,20.26745,48.947247",
     "geom:latitude":48.813319,
     "geom:longitude":19.736197,
@@ -177,10 +177,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.BC.BR",
+        "qs:local_id":"323",
         "wd:id":"Q784394"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"6f6a4efbba756a3775fe0dd7b803a10f",
+    "wof:geomhash":"91b9731d9e422afa68799d0cfb0d6099",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":102080545,
-    "wof:lastmodified":1690865440,
+    "wof:lastmodified":1695886354,
     "wof:name":"Brezno",
     "wof:parent_id":85688355,
     "wof:placetype":"county",

--- a/data/102/080/549/102080549.geojson
+++ b/data/102/080/549/102080549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010443,
-    "geom:area_square_m":85118347.635296,
+    "geom:area_square_m":85118226.721063,
     "geom:bbox":"21.119945,48.714858,21.299633,48.824508",
     "geom:latitude":48.765507,
     "geom:longitude":21.206432,
@@ -222,10 +222,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.K1",
+        "qs:local_id":"422",
         "wd:id":"Q830995"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"1a293d224f25886cacd78c826b2a04f8",
+    "wof:geomhash":"8701394d11dd98c1ea01e1aafdacb2f6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -235,7 +240,7 @@
         }
     ],
     "wof:id":102080549,
-    "wof:lastmodified":1690865446,
+    "wof:lastmodified":1695886358,
     "wof:name":"Ko\u0161ice I",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/551/102080551.geojson
+++ b/data/102/080/551/102080551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130704,
-    "geom:area_square_m":1070197913.722474,
+    "geom:area_square_m":1070197787.056016,
     "geom:bbox":"21.512112,48.332821,22.155534,48.794287",
     "geom:latitude":48.533684,
     "geom:longitude":21.767125,
@@ -174,10 +174,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.TV",
+        "qs:local_id":"42B",
         "wd:id":"Q301318"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"ca4b170bd44c47d10f96bca1526eccc4",
+    "wof:geomhash":"5d9b4514bd2b83ab1a22edf66ced852d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":102080551,
-    "wof:lastmodified":1690865432,
+    "wof:lastmodified":1695886350,
     "wof:name":"Trebi\u0161ov",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/553/102080553.geojson
+++ b/data/102/080/553/102080553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143182,
-    "geom:area_square_m":1169078586.335156,
+    "geom:area_square_m":1169078704.260136,
     "geom:bbox":"20.181215,48.456479,20.83207,48.92383",
     "geom:latitude":48.675491,
     "geom:longitude":20.458092,
@@ -65,10 +65,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.KI.RV"
+        "hasc:id":"SK.KI.RV",
+        "qs:local_id":"428"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"8ba036ada2a948c1905d37574ea5d4b0",
+    "wof:geomhash":"7ebad4f3ad6789987047c067a970f25d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -78,7 +83,7 @@
         }
     ],
     "wof:id":102080553,
-    "wof:lastmodified":1627522780,
+    "wof:lastmodified":1695886473,
     "wof:name":"Ro\u017enava",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/555/102080555.geojson
+++ b/data/102/080/555/102080555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044156,
-    "geom:area_square_m":358232750.158235,
+    "geom:area_square_m":358232927.195164,
     "geom:bbox":"18.090139,48.896014,18.507677,49.145053",
     "geom:latitude":48.996029,
     "geom:longitude":18.250895,
@@ -171,10 +171,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TC.IL",
+        "qs:local_id":"222",
         "wd:id":"Q373881"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"bf8d1dfceacba3b5439f9ce12a80f042",
+    "wof:geomhash":"27b57fab21455acb74f6b3ece5049ce5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -184,7 +189,7 @@
         }
     ],
     "wof:id":102080555,
-    "wof:lastmodified":1690865441,
+    "wof:lastmodified":1695886355,
     "wof:name":"Ilava",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/557/102080557.geojson
+++ b/data/102/080/557/102080557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187252,
-    "geom:area_square_m":1528495366.321758,
+    "geom:area_square_m":1528495634.039011,
     "geom:bbox":"20.736719,48.491058,21.578811,48.905683",
     "geom:latitude":48.689176,
     "geom:longitude":21.178801,
@@ -204,10 +204,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.KS",
+        "qs:local_id":"426",
         "wd:id":"Q539979"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"e49bc4740c9ae12034971ad668fe2437",
+    "wof:geomhash":"dbd458955cd43bec0d4c8212ef45e3f7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -217,7 +222,7 @@
         }
     ],
     "wof:id":102080557,
-    "wof:lastmodified":1690865434,
+    "wof:lastmodified":1695886351,
     "wof:name":"Ko\u0161ice - okolie",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/559/102080559.geojson
+++ b/data/102/080/559/102080559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071455,
-    "geom:area_square_m":581802828.657645,
+    "geom:area_square_m":581802550.354308,
     "geom:bbox":"20.529624,48.667424,21.073327,48.964691",
     "geom:latitude":48.815855,
     "geom:longitude":20.803822,
@@ -180,10 +180,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.GL",
+        "qs:local_id":"421",
         "wd:id":"Q220968"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"cda5e2a8040e8d4c7583fe3a93c3bc8d",
+    "wof:geomhash":"0698d52cf5f4526a38c06aed9836e7f4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -193,7 +198,7 @@
         }
     ],
     "wof:id":102080559,
-    "wof:lastmodified":1690865433,
+    "wof:lastmodified":1695886351,
     "wof:name":"Gelnica",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/561/102080561.geojson
+++ b/data/102/080/561/102080561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071977,
-    "geom:area_square_m":584902272.159264,
+    "geom:area_square_m":584902194.79791,
     "geom:bbox":"20.296234,48.788903,20.921057,49.019882",
     "geom:latitude":48.914144,
     "geom:longitude":20.6119,
@@ -177,10 +177,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.SN",
+        "qs:local_id":"42A",
         "wd:id":"Q756077"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"a5efa88d2a0c50f28e71f210b48dbc6d",
+    "wof:geomhash":"1cdf4296145e7302294e68ede54e5d01",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":102080561,
-    "wof:lastmodified":1690865434,
+    "wof:lastmodified":1695886351,
     "wof:name":"Spi\u0161sk\u00e1 Nov\u00e1 Ves",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/563/102080563.geojson
+++ b/data/102/080/563/102080563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12457,
-    "geom:area_square_m":1017014590.707667,
+    "geom:area_square_m":1017015076.239632,
     "geom:bbox":"21.714756,48.446819,22.16635,48.901982",
     "geom:latitude":48.680588,
     "geom:longitude":21.948943,
@@ -178,10 +178,15 @@
     "wof:concordances":{
         "gp:id":29399316,
         "hasc:id":"SK.KI.MI",
+        "qs:local_id":"427",
         "wd:id":"Q379320"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"0cc0cf726fcd8ebf9ef3dbe45932e574",
+    "wof:geomhash":"c366af2c2be48e08bc5422f506cb4e3f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -191,7 +196,7 @@
         }
     ],
     "wof:id":102080563,
-    "wof:lastmodified":1690865442,
+    "wof:lastmodified":1695886355,
     "wof:name":"Michalovce",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/567/102080567.geojson
+++ b/data/102/080/567/102080567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079412,
-    "geom:area_square_m":643878357.591076,
+    "geom:area_square_m":643878357.591028,
     "geom:bbox":"19.078754,48.8558875,19.461119,49.177029",
     "geom:latitude":49.025707,
     "geom:longitude":19.259504,
@@ -188,10 +188,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.ZI.RK"
+        "hasc:id":"SK.ZI.RK",
+        "qs:local_id":"318"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"a04e2fa684354a3279841658c651aaf4",
+    "wof:geomhash":"58320202aa371503ce9d0b1e94a3bc66",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -201,7 +206,7 @@
         }
     ],
     "wof:id":102080567,
-    "wof:lastmodified":1566645368,
+    "wof:lastmodified":1695886351,
     "wof:name":"Ru\u017eomberok",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/569/102080569.geojson
+++ b/data/102/080/569/102080569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090452,
-    "geom:area_square_m":733286351.463995,
+    "geom:area_square_m":733286302.830304,
     "geom:bbox":"18.63336,48.876659,19.143692,49.218092",
     "geom:latitude":49.032939,
     "geom:longitude":18.946496,
@@ -179,10 +179,15 @@
     "wof:concordances":{
         "gp:id":29399310,
         "hasc:id":"SK.ZI.MT",
+        "qs:local_id":"316",
         "wd:id":"Q756665"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"d6771ae5dadbbc01e1d9995de1e80de6",
+    "wof:geomhash":"be43e90a12da1c1fd26e0f32833bde8b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -192,7 +197,7 @@
         }
     ],
     "wof:id":102080569,
-    "wof:lastmodified":1690865432,
+    "wof:lastmodified":1695886350,
     "wof:name":"Martin",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/571/102080571.geojson
+++ b/data/102/080/571/102080571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065862,
-    "geom:area_square_m":536896065.799555,
+    "geom:area_square_m":536896333.277831,
     "geom:bbox":"22.057026,48.573901,22.387302,48.930196",
     "geom:latitude":48.756818,
     "geom:longitude":22.220639,
@@ -174,10 +174,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.KI.SO",
+        "qs:local_id":"429",
         "wd:id":"Q830991"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"06a7af3634de037cbe48d48e4d0da568",
+    "wof:geomhash":"7a26e36f33d8b44519d3727026c7262d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +192,7 @@
         }
     ],
     "wof:id":102080571,
-    "wof:lastmodified":1690865447,
+    "wof:lastmodified":1695886358,
     "wof:name":"Sobrance",
     "wof:parent_id":85688359,
     "wof:placetype":"county",

--- a/data/102/080/573/102080573.geojson
+++ b/data/102/080/573/102080573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046356,
-    "geom:area_square_m":374988960.865443,
+    "geom:area_square_m":374989284.849727,
     "geom:bbox":"18.117019,48.97084,18.437512,49.296791",
     "geom:latitude":49.140948,
     "geom:longitude":18.26783,
@@ -165,10 +165,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TC.PU",
+        "qs:local_id":"228",
         "wd:id":"Q768310"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"7b1a2b068eef2badc58bde2f9e06e1ba",
+    "wof:geomhash":"fb30d0970094ab9229a2ea71e0daa494",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -178,7 +183,7 @@
         }
     ],
     "wof:id":102080573,
-    "wof:lastmodified":1690865441,
+    "wof:lastmodified":1695886355,
     "wof:name":"P\u00fachov",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/575/102080575.geojson
+++ b/data/102/080/575/102080575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057118,
-    "geom:area_square_m":462079918.547567,
+    "geom:area_square_m":462079774.130507,
     "geom:bbox":"18.247344,48.95636,18.602798,49.319707",
     "geom:latitude":49.136953,
     "geom:longitude":18.438158,
@@ -190,10 +190,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.TC.PB",
+        "qs:local_id":"226",
         "wd:id":"Q837891"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"d0a1a1d24535de0f3e211acdb9bbc932",
+    "wof:geomhash":"50f3d800a7dbcc261e4c3bb3ecd93d5d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -203,7 +208,7 @@
         }
     ],
     "wof:id":102080575,
-    "wof:lastmodified":1690865439,
+    "wof:lastmodified":1695886354,
     "wof:name":"Pova\u017esk\u00e1 Bystrica",
     "wof:parent_id":85688339,
     "wof:placetype":"county",

--- a/data/102/080/577/102080577.geojson
+++ b/data/102/080/577/102080577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164898,
-    "geom:area_square_m":1336221938.812719,
+    "geom:area_square_m":1336222022.956516,
     "geom:bbox":"19.356085,48.896834,20.06043,49.242817",
     "geom:latitude":49.055053,
     "geom:longitude":19.706875,
@@ -191,10 +191,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.ZI.LM",
+        "qs:local_id":"315",
         "wd:id":"Q545302"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"01ed87fca44c22bc1f8969bc20a09500",
+    "wof:geomhash":"5c7a149919de3d47f5fc0614d1ec24b1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -204,7 +209,7 @@
         }
     ],
     "wof:id":102080577,
-    "wof:lastmodified":1690865447,
+    "wof:lastmodified":1695886359,
     "wof:name":"Liptovsk\u00fd Mikul\u00e1\u0161",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/579/102080579.geojson
+++ b/data/102/080/579/102080579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051758,
-    "geom:area_square_m":419514833.603872,
+    "geom:area_square_m":419515055.510454,
     "geom:bbox":"20.437841,48.952238,20.902744,49.155035",
     "geom:latitude":49.042959,
     "geom:longitude":20.686896,
@@ -66,10 +66,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29399309,
-        "hasc:id":"SK.PV.LE"
+        "hasc:id":"SK.PV.LE",
+        "qs:local_id":"414"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"66aa387405a4685c59b3f7679d8cc466",
+    "wof:geomhash":"255559dbf1e94e513cd4e3072a4dbed0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -79,7 +84,7 @@
         }
     ],
     "wof:id":102080579,
-    "wof:lastmodified":1627522780,
+    "wof:lastmodified":1695886474,
     "wof:name":"Levoca",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/581/102080581.geojson
+++ b/data/102/080/581/102080581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034775,
-    "geom:area_square_m":280644881.932976,
+    "geom:area_square_m":280644688.352353,
     "geom:bbox":"18.373404,49.114005,18.642165,49.365079",
     "geom:latitude":49.257145,
     "geom:longitude":18.523157,
@@ -65,10 +65,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.ZI.BY"
+        "hasc:id":"SK.ZI.BY",
+        "qs:local_id":"311"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"b7601c4469fbb4855cad752d2751eed4",
+    "wof:geomhash":"3df3e9efbbec80959ea2888b8532f697",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -78,7 +83,7 @@
         }
     ],
     "wof:id":102080581,
-    "wof:lastmodified":1627522780,
+    "wof:lastmodified":1695886474,
     "wof:name":"Bytca",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/585/102080585.geojson
+++ b/data/102/080/585/102080585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100498,
-    "geom:area_square_m":812430659.985121,
+    "geom:area_square_m":812430659.985168,
     "geom:bbox":"18.4628915,48.9364695,19.1229535,49.3644685",
     "geom:latitude":49.173104,
     "geom:longitude":18.772879,
@@ -248,10 +248,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.ZI.ZA"
+        "hasc:id":"SK.ZI.ZA",
+        "qs:local_id":"31B"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"df77d05e1125140490bb368b55097195",
+    "wof:geomhash":"5b626c2231cfd268086eafff173e0a99",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -261,7 +266,7 @@
         }
     ],
     "wof:id":102080585,
-    "wof:lastmodified":1566645381,
+    "wof:lastmodified":1695886358,
     "wof:name":"\u017dilina",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/587/102080587.geojson
+++ b/data/102/080/587/102080587.geojson
@@ -155,10 +155,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.ZI.DK"
+        "hasc:id":"SK.ZI.DK",
+        "qs:local_id":"313"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"592597fdb690a94fdc1deede33c531ae",
+    "wof:geomhash":"fada4f4d26497767fa5b8f5d360cf332",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -168,7 +173,7 @@
         }
     ],
     "wof:id":102080587,
-    "wof:lastmodified":1566645375,
+    "wof:lastmodified":1695886355,
     "wof:name":"Doln\u00fd Kub\u00edn",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/589/102080589.geojson
+++ b/data/102/080/589/102080589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021477,
-    "geom:area_square_m":173132207.346151,
+    "geom:area_square_m":173132233.14679,
     "geom:bbox":"18.672851,49.247503,18.930911,49.388653",
     "geom:latitude":49.312802,
     "geom:longitude":18.801616,
@@ -193,10 +193,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.ZI.KM",
+        "qs:local_id":"314",
         "wd:id":"Q762646"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"677646d85aa1b7eaafd7d1095cecb20f",
+    "wof:geomhash":"9be9b8fdbabbed85a92cdb51e8df1261",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -206,7 +211,7 @@
         }
     ],
     "wof:id":102080589,
-    "wof:lastmodified":1690865440,
+    "wof:lastmodified":1695886355,
     "wof:name":"Kysuck\u00e9 Nov\u00e9 Mesto",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/591/102080591.geojson
+++ b/data/102/080/591/102080591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114758,
-    "geom:area_square_m":931150283.696655,
+    "geom:area_square_m":931150224.019396,
     "geom:bbox":"20.870505,48.810735,21.485853,49.185155",
     "geom:latitude":48.98925,
     "geom:longitude":21.213164,
@@ -177,10 +177,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.PV.PO",
+        "qs:local_id":"417",
         "wd:id":"Q756658"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"2567832e537ca1b1a2e2a41f223cc1bc",
+    "wof:geomhash":"8a35a4aebbe56890a0660170ab28de1b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -190,7 +195,7 @@
         }
     ],
     "wof:id":102080591,
-    "wof:lastmodified":1690865443,
+    "wof:lastmodified":1695886356,
     "wof:name":"Pre\u0161ov",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/593/102080593.geojson
+++ b/data/102/080/593/102080593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094392,
-    "geom:area_square_m":766701114.527324,
+    "geom:area_square_m":766701072.882621,
     "geom:bbox":"21.404362,48.762556,21.806968,49.132453",
     "geom:latitude":48.937259,
     "geom:longitude":21.626507,
@@ -66,10 +66,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29399307,
-        "hasc:id":"SK.PV.VT"
+        "hasc:id":"SK.PV.VT",
+        "qs:local_id":"41D"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"eb57bbcac0752fa3f8d8b5b053619420",
+    "wof:geomhash":"47484472412b450adafbc770cc740dc6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -79,7 +84,7 @@
         }
     ],
     "wof:id":102080593,
-    "wof:lastmodified":1627522781,
+    "wof:lastmodified":1695886474,
     "wof:name":"Vranov nad Toplou",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/595/102080595.geojson
+++ b/data/102/080/595/102080595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067214,
-    "geom:area_square_m":543697245.875149,
+    "geom:area_square_m":543697192.458596,
     "geom:bbox":"20.652174,49.020746,21.227101,49.23185",
     "geom:latitude":49.142659,
     "geom:longitude":20.966083,
@@ -175,10 +175,15 @@
     "wof:concordances":{
         "gp:id":29399304,
         "hasc:id":"SK.PV.SB",
+        "qs:local_id":"418",
         "wd:id":"Q747926"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"b7a272505999a35caeda177f9918ae79",
+    "wof:geomhash":"0d4f61a986657718ddc06652f06f91cc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -188,7 +193,7 @@
         }
     ],
     "wof:id":102080595,
-    "wof:lastmodified":1690865434,
+    "wof:lastmodified":1695886351,
     "wof:name":"Sabinov",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/597/102080597.geojson
+++ b/data/102/080/597/102080597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135012,
-    "geom:area_square_m":1093348158.901827,
+    "geom:area_square_m":1093348405.584066,
     "geom:bbox":"19.885967,48.871014,20.457246,49.326412",
     "geom:latitude":49.086605,
     "geom:longitude":20.176072,
@@ -175,10 +175,15 @@
     "wof:concordances":{
         "gp:id":29399351,
         "hasc:id":"SK.PV.PP",
+        "qs:local_id":"416",
         "wd:id":"Q830982"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"65a2dd1504fd41493fce5b8d5c029464",
+    "wof:geomhash":"787300a3a5f64ff6bb50bb4032b6af89",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -188,7 +193,7 @@
         }
     ],
     "wof:id":102080597,
-    "wof:lastmodified":1690865442,
+    "wof:lastmodified":1695886355,
     "wof:name":"Poprad",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/599/102080599.geojson
+++ b/data/102/080/599/102080599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09829,
-    "geom:area_square_m":796995619.943842,
+    "geom:area_square_m":796995786.743526,
     "geom:bbox":"22.016158,48.864761,22.569116,49.186222",
     "geom:latitude":49.022429,
     "geom:longitude":22.290709,
@@ -168,10 +168,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.PV.SV",
+        "qs:local_id":"419",
         "wd:id":"Q837888"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"bbef564112e8668c7585a74f57f11424",
+    "wof:geomhash":"99f46e35b8630ace4c1b22aa7e1ecb74",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":102080599,
-    "wof:lastmodified":1690865441,
+    "wof:lastmodified":1695886356,
     "wof:name":"Snina",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/603/102080603.geojson
+++ b/data/102/080/603/102080603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092651,
-    "geom:area_square_m":751520663.005967,
+    "geom:area_square_m":751520294.619359,
     "geom:bbox":"21.742329,48.838639,22.191751,49.202511",
     "geom:latitude":49.005992,
     "geom:longitude":21.95233,
@@ -175,10 +175,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.PV.HE",
+        "qs:local_id":"412",
         "wd:id":"Q837897"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"02e5707a3593077f3805a9a358a6decb",
+    "wof:geomhash":"c873e22ea5f2a6b4f75a84441c1ab7d3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -188,7 +193,7 @@
         }
     ],
     "wof:id":102080603,
-    "wof:lastmodified":1690865437,
+    "wof:lastmodified":1695886354,
     "wof:name":"Humenn\u00e9",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/605/102080605.geojson
+++ b/data/102/080/605/102080605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060055,
-    "geom:area_square_m":484041398.972831,
+    "geom:area_square_m":484041228.920335,
     "geom:bbox":"19.420215,49.196329,19.823957,49.460427",
     "geom:latitude":49.320179,
     "geom:longitude":19.644252,
@@ -169,10 +169,15 @@
     "wof:concordances":{
         "gp:id":29399298,
         "hasc:id":"SK.ZI.TS",
+        "qs:local_id":"31A",
         "wd:id":"Q756899"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"db5ca2f72dbac61032b2e0293596a131",
+    "wof:geomhash":"3562a6cc46ccb5b0ab16ca81a6da5565",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -182,7 +187,7 @@
         }
     ],
     "wof:id":102080605,
-    "wof:lastmodified":1690865436,
+    "wof:lastmodified":1695886353,
     "wof:name":"Tvrdo\u0161\u00edn",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/607/102080607.geojson
+++ b/data/102/080/607/102080607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094274,
-    "geom:area_square_m":758470845.982987,
+    "geom:area_square_m":758470695.71579,
     "geom:bbox":"18.323172,49.298155,19.160534,49.519387",
     "geom:latitude":49.409532,
     "geom:longitude":18.784941,
@@ -190,10 +190,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.ZI.CA",
+        "qs:local_id":"312",
         "wd:id":"Q836173"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"5dfebae05c4c68960335c0d3cb7d8d01",
+    "wof:geomhash":"ce3aa0dad6afb80408397c72399b8cc0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -203,7 +208,7 @@
         }
     ],
     "wof:id":102080607,
-    "wof:lastmodified":1690865446,
+    "wof:lastmodified":1695886357,
     "wof:name":"Cadca",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/609/102080609.geojson
+++ b/data/102/080/609/102080609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077234,
-    "geom:area_square_m":623937118.478977,
+    "geom:area_square_m":623937118.478964,
     "geom:bbox":"20.182245,49.0317445,20.642232,49.407887",
     "geom:latitude":49.207159,
     "geom:longitude":20.425671,
@@ -183,10 +183,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":29399297,
-        "hasc:id":"SK.PV.KK"
+        "hasc:id":"SK.PV.KK",
+        "qs:local_id":"413"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"67750808eebbac7646387f387451b331",
+    "wof:geomhash":"d610e3f2810f55a59422d142f8e44d05",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -196,7 +201,7 @@
         }
     ],
     "wof:id":102080609,
-    "wof:lastmodified":1566645380,
+    "wof:lastmodified":1695886358,
     "wof:name":"Ke\u017emarok",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/611/102080611.geojson
+++ b/data/102/080/611/102080611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087258,
-    "geom:area_square_m":703645504.428921,
+    "geom:area_square_m":703645504.428923,
     "geom:bbox":"20.4013385,49.151639,21.01563,49.4197195",
     "geom:latitude":49.295813,
     "geom:longitude":20.693151,
@@ -92,10 +92,15 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"SK.PV.SL"
+        "hasc:id":"SK.PV.SL",
+        "qs:local_id":"41A"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"50ccbd8bc712277a33df38596e019fc9",
+    "wof:geomhash":"fed25632be84677bb654aa04ecd8295d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -105,7 +110,7 @@
         }
     ],
     "wof:id":102080611,
-    "wof:lastmodified":1566645371,
+    "wof:lastmodified":1695886352,
     "wof:name":"Star\u00e1 Lubovna",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/613/102080613.geojson
+++ b/data/102/080/613/102080613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048006,
-    "geom:area_square_m":387792125.397021,
+    "geom:area_square_m":387792165.080455,
     "geom:bbox":"21.569288,49.043183,21.870343,49.363961",
     "geom:latitude":49.210218,
     "geom:longitude":21.703794,
@@ -168,10 +168,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.PV.SP",
+        "qs:local_id":"41B",
         "wd:id":"Q777963"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"3f29a594812a62a18185a6b054a428ca",
+    "wof:geomhash":"54c563db7c35511c5b751391daed92ea",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":102080613,
-    "wof:lastmodified":1690865443,
+    "wof:lastmodified":1695886356,
     "wof:name":"Stropkov",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/615/102080615.geojson
+++ b/data/102/080/615/102080615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084745,
-    "geom:area_square_m":681449713.850622,
+    "geom:area_square_m":681449597.82576,
     "geom:bbox":"19.111201,49.27955,19.596869,49.609993",
     "geom:latitude":49.435233,
     "geom:longitude":19.368968,
@@ -166,10 +166,15 @@
     "wof:concordances":{
         "gp:id":29399291,
         "hasc:id":"SK.ZI.NO",
+        "qs:local_id":"317",
         "wd:id":"Q388888"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"02023c41ecf34b77d70795615e86adaf",
+    "wof:geomhash":"f47f54e70fd29dd05e22d6dbc7ec544c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -179,7 +184,7 @@
         }
     ],
     "wof:id":102080615,
-    "wof:lastmodified":1690865444,
+    "wof:lastmodified":1695886357,
     "wof:name":"N\u00e1mestovo",
     "wof:parent_id":85688349,
     "wof:placetype":"county",

--- a/data/102/080/617/102080617.geojson
+++ b/data/102/080/617/102080617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05259,
-    "geom:area_square_m":424665374.262719,
+    "geom:area_square_m":424665536.195484,
     "geom:bbox":"21.785588,49.098857,22.107857,49.390255",
     "geom:latitude":49.228806,
     "geom:longitude":21.926618,
@@ -168,10 +168,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.PV.ML",
+        "qs:local_id":"415",
         "wd:id":"Q837884"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"a9071e3e9b464244c4a335de141f1706",
+    "wof:geomhash":"4f4c75008841d46dc2db972dcf89c973",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":102080617,
-    "wof:lastmodified":1690865435,
+    "wof:lastmodified":1695886352,
     "wof:name":"Medzilaborce",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/621/102080621.geojson
+++ b/data/102/080/621/102080621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114426,
-    "geom:area_square_m":922926982.806141,
+    "geom:area_square_m":922926978.8324,
     "geom:bbox":"20.986643,49.112727,21.536782,49.45869",
     "geom:latitude":49.285227,
     "geom:longitude":21.262972,
@@ -168,10 +168,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.PV.BJ",
+        "qs:local_id":"411",
         "wd:id":"Q265964"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"e0f2b3ae9e3e1bfce43fb7decce72ed8",
+    "wof:geomhash":"9933ed9af6e07b5720cc97ae3610611e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -181,7 +186,7 @@
         }
     ],
     "wof:id":102080621,
-    "wof:lastmodified":1690865436,
+    "wof:lastmodified":1695886353,
     "wof:name":"Bardejov",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/102/080/623/102080623.geojson
+++ b/data/102/080/623/102080623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067443,
-    "geom:area_square_m":543910912.685473,
+    "geom:area_square_m":543910778.705167,
     "geom:bbox":"21.368927,49.06421,21.774036,49.445313",
     "geom:latitude":49.291247,
     "geom:longitude":21.558739,
@@ -190,10 +190,15 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"SK.PV.SK",
+        "qs:local_id":"41C",
         "wd:id":"Q385823"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "hasc:id"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"be778a28af3c9159f2e257f18c804ced",
+    "wof:geomhash":"aead4455df4d29efd0fb1d998587f598",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -203,7 +208,7 @@
         }
     ],
     "wof:id":102080623,
-    "wof:lastmodified":1690865444,
+    "wof:lastmodified":1695886357,
     "wof:name":"Svidn\u00edk",
     "wof:parent_id":85688347,
     "wof:placetype":"county",

--- a/data/856/337/69/85633769.geojson
+++ b/data/856/337/69/85633769.geojson
@@ -1315,6 +1315,7 @@
         "hasc:id":"SK",
         "icao:code":"OM",
         "ioc:id":"SVK",
+        "iso:code":"SK",
         "itu:id":"SVK",
         "loc:id":"n50075233",
         "m49:code":"703",
@@ -1329,6 +1330,7 @@
         "wk:page":"Slovakia",
         "wmo:id":"SQ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SK",
     "wof:country_alpha3":"SVK",
     "wof:geom_alt":[
@@ -1349,7 +1351,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1694492261,
+    "wof:lastmodified":1695881374,
     "wof:name":"Slovakia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/883/39/85688339.geojson
+++ b/data/856/883/39/85688339.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":0.552044,
-    "geom:area_square_m":4491022873.128551,
+    "geom:area_square_m":4491023255.133854,
     "geom:bbox":"17.353044,48.485686,18.82687,49.319707",
     "geom:latitude":48.858651,
     "geom:longitude":18.213216,
@@ -370,12 +370,18 @@
         "gn:id":3343957,
         "gp:id":20070493,
         "hasc:id":"SK.TC",
+        "iso:code":"SK-TC",
         "iso:id":"SK-TC",
+        "qs:local_id":"22",
         "unlc:id":"SK-TC",
         "wd:id":"Q183139"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"a05b0e8e12c9ad11df36c248f9c869a3",
+    "wof:geomhash":"11fd0758fcb30c3f9df444e0d71ae4e0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -390,7 +396,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1690865456,
+    "wof:lastmodified":1695885321,
     "wof:name":"Trenciansky kraj",
     "wof:parent_id":85633769,
     "wof:placetype":"region",

--- a/data/856/883/47/85688347.geojson
+++ b/data/856/883/47/85688347.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"3",
     "geom:area":1.101032,
-    "geom:area_square_m":8909805937.613794,
+    "geom:area_square_m":8909806147.953598,
     "geom:bbox":"19.885967,48.762556,22.569116,49.45869",
     "geom:latitude":49.122907,
     "geom:longitude":21.225362,
@@ -377,12 +377,18 @@
         "gn:id":865085,
         "gp:id":20070496,
         "hasc:id":"SK.PV",
+        "iso:code":"SK-PV",
         "iso:id":"SK-PV",
+        "qs:local_id":"41",
         "unlc:id":"SK-PV",
         "wd:id":"Q189001"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"c1692f75542152fae7647b1b2a837d20",
+    "wof:geomhash":"3855127758bcea57156e807f80aac37f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -397,7 +403,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1690865458,
+    "wof:lastmodified":1695885321,
     "wof:name":"Pre\u0161ovsk\u00fd kraj",
     "wof:parent_id":85633769,
     "wof:placetype":"region",

--- a/data/856/883/49/85688349.geojson
+++ b/data/856/883/49/85688349.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":0.839454,
-    "geom:area_square_m":6785586656.510358,
+    "geom:area_square_m":6785586482.068696,
     "geom:bbox":"18.323172,48.741156,20.06043,49.609993",
     "geom:latitude":49.177369,
     "geom:longitude":19.177931,
@@ -383,12 +383,18 @@
         "gn:id":3056506,
         "gp:id":20070494,
         "hasc:id":"SK.ZI",
+        "iso:code":"SK-ZI",
         "iso:id":"SK-ZI",
+        "qs:local_id":"31",
         "unlc:id":"SK-ZI",
         "wd:id":"Q184228"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"1c9c84bcb61bfafea80eb6b18ffd147c",
+    "wof:geomhash":"115730f8c9328b5c920c7793a2bcb5b5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -403,7 +409,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1690865457,
+    "wof:lastmodified":1695885321,
     "wof:name":"\u017dilinsk\u00fd kraj",
     "wof:parent_id":85633769,
     "wof:placetype":"region",

--- a/data/856/883/55/85688355.geojson
+++ b/data/856/883/55/85688355.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"3",
     "geom:area":1.150852,
-    "geom:area_square_m":9426432107.405907,
+    "geom:area_square_m":9426431894.661898,
     "geom:bbox":"18.478677,48.053829,20.46982,48.947247",
     "geom:latitude":48.515732,
     "geom:longitude":19.503936,
@@ -385,12 +385,18 @@
         "gn:id":3343954,
         "gp:id":20070495,
         "hasc:id":"SK.BC",
+        "iso:code":"SK-BC",
         "iso:id":"SK-BC",
+        "qs:local_id":"32",
         "unlc:id":"SK-BC",
         "wd:id":"Q183640"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"4a8faca1135411c21143d7c1f4e4a723",
+    "wof:geomhash":"37a5401ac179266a15b7596cef270f32",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -405,7 +411,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1690865457,
+    "wof:lastmodified":1695885321,
     "wof:name":"Banskobystrick\u00fd kraj",
     "wof:parent_id":85633769,
     "wof:placetype":"region",

--- a/data/856/883/59/85688359.geojson
+++ b/data/856/883/59/85688359.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":0.824778,
-    "geom:area_square_m":6731388515.552247,
+    "geom:area_square_m":6731388937.121466,
     "geom:bbox":"20.181215,48.332821,22.387302,49.019882",
     "geom:latitude":48.69739,
     "geom:longitude":21.266267,
@@ -377,12 +377,18 @@
         "gn:id":865084,
         "gp:id":20070497,
         "hasc:id":"SK.KI",
+        "iso:code":"SK-KI",
         "iso:id":"SK-KI",
+        "qs:local_id":"42",
         "unlc:id":"SK-KI",
         "wd:id":"Q186295"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"7a4dd8005033d09c288aaafd4a07bdb4",
+    "wof:geomhash":"fe42a26933fa218c7111e54e283319c7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -397,7 +403,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1690865455,
+    "wof:lastmodified":1695885321,
     "wof:name":"Ko\u0161ick\u00fd kraj",
     "wof:parent_id":85633769,
     "wof:placetype":"region",

--- a/data/856/883/65/85688365.geojson
+++ b/data/856/883/65/85688365.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"2",
     "geom:area":0.766477,
-    "geom:area_square_m":6324259279.134541,
+    "geom:area_square_m":6324258564.287527,
     "geom:bbox":"17.70824,47.7313,19.072128,48.714432",
     "geom:latitude":48.141941,
     "geom:longitude":18.31083,
@@ -365,12 +365,18 @@
         "gn:id":3343956,
         "gp:id":20070492,
         "hasc:id":"SK.NI",
+        "iso:code":"SK-NI",
         "iso:id":"SK-NI",
+        "qs:local_id":"23",
         "unlc:id":"SK-NI",
         "wd:id":"Q184548"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"70f5bd1d616a1f8c1ffd68e1c581da5d",
+    "wof:geomhash":"4c4a3628c40a17aca148e222f5a03e03",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -385,7 +391,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1690865456,
+    "wof:lastmodified":1695885321,
     "wof:name":"Nitriansky kraj",
     "wof:parent_id":85633769,
     "wof:placetype":"region",

--- a/data/856/883/69/85688369.geojson
+++ b/data/856/883/69/85688369.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"3",
     "geom:area":0.503193,
-    "geom:area_square_m":4134750205.986979,
+    "geom:area_square_m":4134750411.056263,
     "geom:bbox":"16.93375,47.757096,17.985486,48.878223",
     "geom:latitude":48.353162,
     "geom:longitude":17.534769,
@@ -373,12 +373,18 @@
         "gn:id":3343958,
         "gp:id":20070504,
         "hasc:id":"SK.TA",
+        "iso:code":"SK-TA",
         "iso:id":"SK-TA",
+        "qs:local_id":"21",
         "unlc:id":"SK-TA",
         "wd:id":"Q181342"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"379855650dc6ac92c962e19c8a682c76",
+    "wof:geomhash":"46907732db05a10298eaab22aee463dd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -393,7 +399,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1690865455,
+    "wof:lastmodified":1695885322,
     "wof:name":"Trnavsk\u00fd kraj",
     "wof:parent_id":85633769,
     "wof:placetype":"region",

--- a/data/856/883/73/85688373.geojson
+++ b/data/856/883/73/85688373.geojson
@@ -19,7 +19,7 @@
     "eurostat:population_year":2022,
     "eurostat:urban_type":"1",
     "geom:area":0.248712,
-    "geom:area_square_m":2045129273.019445,
+    "geom:area_square_m":2045129459.675428,
     "geom:bbox":"16.832695,48.006714,17.529213,48.654027",
     "geom:latitude":48.317433,
     "geom:longitude":17.179147,
@@ -380,12 +380,18 @@
         "gn:id":3343955,
         "gp:id":20070505,
         "hasc:id":"SK.BL",
+        "iso:code":"SK-BL",
         "iso:id":"SK-BL",
+        "qs:local_id":"10",
         "unlc:id":"SK-BL",
         "wd:id":"Q183498"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"SK",
-    "wof:geomhash":"ed2330e9dea8a36629f1c145c3ec3ed7",
+    "wof:geomhash":"9146b97a9051ce134d3cb4bd3ef3c785",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +406,7 @@
     "wof:lang_x_spoken":[
         "slk"
     ],
-    "wof:lastmodified":1690865456,
+    "wof:lastmodified":1695885322,
     "wof:name":"Bratislavsk\u00fd kraj",
     "wof:parent_id":85633769,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.