### PR TITLE
18: Fix Kosice county name

### DIFF
--- a/data/102/080/557/102080557.geojson
+++ b/data/102/080/557/102080557.geojson
@@ -35,7 +35,7 @@
         "\u041a\u043e\u0448\u044b\u0446\u044b-\u0430\u043a\u043e\u043b\u0456\u0446\u0430"
     ],
     "name:cat_x_preferred":[
-        "Peder"
+        "Ko0161ice-okolie"
     ],
     "name:ceb_x_preferred":[
         "Okres Kosice-okolie"
@@ -56,7 +56,7 @@
         "Ko\u0161ice-okolie District"
     ],
     "name:epo_x_preferred":[
-        "Peder"
+        "Ko0161ice-okolie"
     ],
     "name:epo_x_variant":[
         "Distrikto Ko\u0161ice-\u0109irka\u016da\u0135o"
@@ -65,7 +65,7 @@
         "Ko\u0161ice-okolie barrutia"
     ],
     "name:fra_x_preferred":[
-        "Peder"
+        "Ko0161ice-okolie"
     ],
     "name:fra_x_variant":[
         "District de Ko\u0161ice-okolie",
@@ -81,7 +81,7 @@
         "Kassa-k\u00f6rny\u00e9ki j\u00e1r\u00e1s"
     ],
     "name:ita_x_preferred":[
-        "Peder"
+        "Ko0161ice-okolie"
     ],
     "name:jpn_x_preferred":[
         "\u30b3\u30b7\u30c4\u30a7\u8fd1\u90ca\u90e1"
@@ -99,7 +99,7 @@
         "Ko\u0161ices apk\u0101rtnes apri\u0146\u0137is"
     ],
     "name:msa_x_preferred":[
-        "Peder"
+        "Ko0161ice-okolie"
     ],
     "name:msa_x_variant":[
         "Daerah Ko\u0161ice-okolie"
@@ -108,7 +108,7 @@
         "Ko\u0161ice-okolie Ko\u0101n"
     ],
     "name:nld_x_preferred":[
-        "Peder"
+        "Ko0161ice-okolie"
     ],
     "name:nld_x_variant":[
         "Okres Ko\u0161ice-okolie"
@@ -117,7 +117,7 @@
         "Ko\u0161ice-okolie"
     ],
     "name:pol_x_preferred":[
-        "Peder"
+        "Ko0161ice-okolie"
     ],
     "name:pol_x_variant":[
         "Powiat Koszyce-okolice"
@@ -138,7 +138,7 @@
         "\u041a\u043e\u0448\u0438\u0446\u0435-\u043f\u0435\u0440\u0438\u0444\u0435\u0440\u0438\u044f"
     ],
     "name:slk_x_preferred":[
-        "Peder"
+        "Ko\u0161ice-okolie"
     ],
     "name:slk_x_variant":[
         "Ko\u0161ice-okolie",


### PR DESCRIPTION
### 18: Fix Kosice county name

Kosice county has the name of Peder in some languages, which coresponds to a city. Updated preferred name to the correct string

